### PR TITLE
Fixing tuple check for persist

### DIFF
--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -38,9 +38,9 @@ import pickle
 import zipfile
 import zlib
 try:
-    from collections.abc import Mapping, MutableMapping, Iterable
+    from collections.abc import Mapping, MutableMapping
 except ImportError:
-    from collections import Mapping, MutableMapping, Iterable
+    from collections import Mapping, MutableMapping
 
 import awkward.type
 import awkward.util
@@ -278,8 +278,11 @@ def serialize(obj, storage, name=None, delimiter="-", suffix=None, schemasuffix=
 
         minsize = x.get("minsize", 0)
         tpes = x.get("types", (object,))
-        if not isinstance(tpes, Iterable):
-            tpes = (tpes,)
+        if not isinstance(tpes, tuple):
+            try:
+                tpes = tuple(tpes)
+            except TypeError:
+                tpes = (tpes,)
         contexts = x.get("contexts", "*")
         pair = x["pair"]
 

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
This should fix the problem I'm seeing with large arrays - the default compression types is a list, and that's clashing with the explicit check for tuples. An originally failing but now passing test could be added to #22.