### PR TITLE
Issue 51

### DIFF
--- a/awkward/array/indexed.py
+++ b/awkward/array/indexed.py
@@ -150,7 +150,11 @@ class IndexedArray(awkward.array.base.AwkwardArrayWithContent):
 
         if awkward.util.isstringslice(where):
             content = self._content[where]
-            return awkward.array.objects.Methods.maybemixin(type(content), IndexedArray)(self._index, content)
+            cls = awkward.array.objects.Methods.maybemixin(type(content), IndexedArray)
+            out = cls.__new__(cls)
+            out.__dict__.update(self.__dict__)
+            out._content = content
+            return out
 
         if isinstance(where, tuple) and len(where) == 0:
             return self
@@ -564,7 +568,11 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
 
         if awkward.util.isstringslice(where):
             content = self._content[where]
-            return awkward.array.objects.Methods.maybemixin(type(content), SparseArray)(self._length, self._index, content, self._default)
+            cls = awkward.array.objects.Methods.maybemixin(type(content), SparseArray)
+            out = cls.__new__(cls)
+            out.__dict__.update(self.__dict__)
+            out._content = content
+            return out
 
         if isinstance(where, tuple) and len(where) == 0:
             return self

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -139,13 +139,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
     @classmethod
     def fromoffsets(cls, offsets, content):
         offsets = awkward.util.toarray(offsets, awkward.util.INDEXTYPE, awkward.util.numpy.ndarray)
-        if not issubclass(offsets.dtype.type, awkward.util.numpy.integer):
-            raise TypeError("offsets must have integer dtype")
-        if len(offsets.shape) != 1 or (offsets < 0).any():
-            raise ValueError("offsets must be a one-dimensional, non-negative array")
-        out = cls(offsets[:-1], offsets[1:], content)
-        out._offsets = offsets
-        return out
+        return cls(offsets[:-1], offsets[1:], content)
 
     @classmethod
     def fromcounts(cls, counts, content):

--- a/awkward/array/masked.py
+++ b/awkward/array/masked.py
@@ -195,7 +195,11 @@ class MaskedArray(awkward.array.base.AwkwardArrayWithContent):
 
         if awkward.util.isstringslice(where):
             content = self._content[where]
-            return awkward.array.objects.Methods.maybemixin(type(content), MaskedArray)(self._mask, content, self._maskedwhen)
+            cls = awkward.array.objects.Methods.maybemixin(type(content), MaskedArray)
+            out = cls.__new__(cls)
+            out.__dict__.update(self.__dict__)
+            out._content = content
+            return out
 
         if isinstance(where, tuple) and len(where) == 0:
             return self
@@ -488,7 +492,11 @@ class BitMaskedArray(MaskedArray):
 
         if awkward.util.isstringslice(where):
             content = self._content[where]
-            return awkward.array.objects.Methods.maybemixin(type(content), BitMaskedArray)(self._mask, content, self._maskedwhen, self._lsborder)
+            cls = awkward.array.objects.Methods.maybemixin(type(content), BitMaskedArray)
+            out = cls.__new__(cls)
+            out.__dict__.update(self.__dict__)
+            out._content = content
+            return out
 
         if isinstance(where, tuple) and len(where) == 0:
             return self
@@ -623,7 +631,11 @@ class IndexedMaskedArray(MaskedArray):
 
         if awkward.util.isstringslice(where):
             content = self._content[where]
-            return awkward.array.objects.Methods.maybemixin(type(content), IndexedMaskedArray)(self._mask, content, self._maskedwhen)
+            cls = awkward.array.objects.Methods.maybemixin(type(content), IndexedMaskedArray)
+            out = cls.__new__(cls)
+            out.__dict__.update(self.__dict__)
+            out._content = content
+            return out
 
         if isinstance(where, tuple) and len(where) == 0:
             return self

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -231,7 +231,7 @@ def jsonable(obj):
     elif isinstance(obj, (numbers.Integral, awkward.util.numpy.integer)):
         return int(obj)       # policy: eliminate Numpy types
 
-    elif isinstance(obj, (numbers.Real, awkward.util.numpy.floating)) and awkward.util.numpy.finite(obj):
+    elif isinstance(obj, (numbers.Real, awkward.util.numpy.floating)) and awkward.util.numpy.isfinite(obj):
         return float(obj)     # policy: eliminate Numpy types
 
     else:

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Addresses #51 in a few ways:

   * If constructing a JaggedArray with `starts` and `stops` that happen to viewing a single `offsets`, do simpler constructor tests.
   * The `_valid()` check for a JaggedArray with `starts` and `stops` that happen to be viewing a single `offsets` are also simpler.
   * When selecting a field from a table, pass on all cached metadata, including `_isvalid`, because it's correct for the columnar view.
