### PR TITLE
Forbid in place operations

### DIFF
--- a/awkward/array/chunked.py
+++ b/awkward/array/chunked.py
@@ -518,6 +518,9 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         import awkward.array.objects
 
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/array/indexed.py
+++ b/awkward/array/indexed.py
@@ -190,6 +190,9 @@ class IndexedArray(awkward.array.base.AwkwardArrayWithContent):
             raise TypeError("invalid index for assigning column to Table: {0}".format(where))
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 
@@ -581,6 +584,9 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
             raise TypeError("invalid index for assigning column to Table: {0}".format(where))
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -845,6 +845,9 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         import awkward.array.objects
         import awkward.array.table
 
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/array/masked.py
+++ b/awkward/array/masked.py
@@ -215,6 +215,9 @@ class MaskedArray(awkward.array.base.AwkwardArrayWithContent):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         import awkward.array.objects
 
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/array/objects.py
+++ b/awkward/array/objects.py
@@ -204,6 +204,9 @@ class ObjectArray(awkward.array.base.AwkwardArrayWithContent):
             return [x[tail] for x in content]   # FIXME: in self.copy(content=content), right?
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 
@@ -240,6 +243,9 @@ class StringMethods(object):
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         import awkward.array.jagged
+
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
 
         if method != "__call__":
             raise NotImplemented

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -114,6 +114,9 @@ class Table(awkward.array.base.AwkwardArray):
                 return self._table.Row(table, index + where)
 
         def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+            if "out" in kwargs:
+                raise NotImplementedError("in-place operations not supported")
+
             if method != "__call__":
                 return NotImplemented
 
@@ -591,6 +594,9 @@ class Table(awkward.array.base.AwkwardArray):
             raise TypeError("invalid index for removing column from Table: {0}".format(where))
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/array/union.py
+++ b/awkward/array/union.py
@@ -336,6 +336,9 @@ class UnionArray(awkward.array.base.AwkwardArray):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         import awkward.array.objects
 
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/array/virtual.py
+++ b/awkward/array/virtual.py
@@ -359,6 +359,9 @@ class VirtualArray(awkward.array.base.AwkwardArray):
             self._delitem.append(where)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if "out" in kwargs:
+            raise NotImplementedError("in-place operations not supported")
+
         if method != "__call__":
             return NotImplemented
 

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
The `out` parameter in Numpy ufuncs are for in-place operations. awkward-array does not support in-place operations, so we detect this and forbid it.