### PR TITLE
Allow older awkwardarrys to be read in from hdf5

### DIFF
--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -55,6 +55,7 @@ partner = {
     }
 
 whitelist = [["awkward.util", "frombuffer"],
+             ["numpy", "frombuffer"],
              ["zlib", "decompress"],
              ["awkward", "*Array"],
              ["awkward", "Table"],


### PR DESCRIPTION
Possible fix for and closes #67.