### PR TITLE
Implement direct argdistincts calculation

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -953,42 +953,43 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         out._parents = parents
         return out
 
-    def _argdistincts(self, add_starts):
-        counts_comb = self.counts*(self.counts-1)//2
+    def _argdistincts(self, absolute):
+        counts_comb = self.counts*(self.counts - 1) // 2
         offsets_comb = self.counts2offsets(counts_comb)
         parents_comb = self.offsets2parents(offsets_comb)
         local_indices = self.numpy.arange(offsets_comb[-1]) - offsets_comb[parents_comb]
 
-        # Consider the double-loop:
-        # for i in range(n):
-        #     for j in range(i+1, n):
-        #         pairs.append((i,j))
+        ### Consider the double-loop:
+        #   for i in range(n):
+        #       for j in range(i + 1, n):
+        #           pairs.append((i, j))
         # At the beginning the i-th iteration of the outer loop,
-        #   len(pairs) = L = (n-1) + (n-2) + ... + (n-i)
-        #                  = n*i - i*(i+1)/2
-        #   ==>  -i^2 + (2n-1)*i - 2*L = 0
+        #   len(pairs) = L = (n - 1) + (n - 2) + ... + (n - i)
+        #                  = n*i - i*(i + 1)/2
+        #   => -i^2 + (2*n - 1)*i - 2*L = 0
         # So the quadratic formula gives i as a function of L at that point:
-        #    i = [(2*n-1) - sqrt((2*n-1)^2 - 4*2*L)]/2
+        #   i = [(2*n - 1) - sqrt((2*n - 1)^2 - 4*2*L)] / 2
         # Since i(L) is monotone increasing, and won't reach i+1 until
         # the next outer loop, the floor gives the i value inside the outer loop.
         # To find j, we can subtract L from our local indices to get the index
-        # from zero of the inner loop, then add i+1
-        n = self.counts[parents_comb]
-        b = 2*n-1
-        i = self.numpy.floor((b-self.numpy.sqrt(b*b-8*local_indices))/2).astype(counts_comb.dtype)
-        j = local_indices + i*(i-b+2)//2 + 1
+        # from zero of the inner loop, then add i + 1.
 
-        if add_starts:
+        n = self.counts[parents_comb]
+        b = 2*n - 1
+        i = self.numpy.floor((b - self.numpy.sqrt(b*b - 8*local_indices)) / 2).astype(counts_comb.dtype)
+        j = local_indices + i*(i - b + 2) // 2 + 1
+
+        if absolute:
             starts_parents = self._starts[parents_comb]
             i += starts_parents
             j += starts_parents
 
-        out = JaggedArray.fromoffsets(offsets_comb, self.Table.named("tuple", i, j))
+        out = self.JaggedArray.fromoffsets(offsets_comb, self.Table.named("tuple", i, j))
         out._parents = parents_comb
         return out
 
     def argdistincts(self, nested=False):
-        out = self._argdistincts(add_starts=False)
+        out = self._argdistincts(absolute=False)
 
         if nested:
             out = JaggedArray.fromcounts(self.numpy.maximum(0, self.counts - 1), JaggedArray.fromcounts(self.index[:, :0:-1].flatten(), out._content))
@@ -996,7 +997,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         return out
 
     def distincts(self, nested=False):
-        argpairs = self._argdistincts(add_starts=True)
+        argpairs = self._argdistincts(absolute=True)
         left = argpairs._content["0"]
         right = argpairs._content["1"]
 

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -966,7 +966,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         # At the beginning the i-th iteration of the outer loop,
         #   len(pairs) = L = (n-1) + (n-2) + ... + (n-i)
         #                  = n*i - i*(i+1)/2
-        #   ==>  -i^2 + (2i-1)*n - 2*L = 0
+        #   ==>  -i^2 + (2n-1)*i - 2*L = 0
         # So the quadratic formula gives i as a function of L at that point:
         #    i = [(2*n-1) - sqrt((2*n-1)^2 - 4*2*L)]/2
         # Since i(L) is monotone increasing, and won't reach i+1 until


### PR DESCRIPTION
This saves two expensive numpy.take() operations and also adds some badly-needed documentation.
PR with respect to #70 

While working on this, I actually found that another ordering of distinct pairs gives much simpler code (although about the same performance): `[[0,1], [0,2], [1,2], [0,3], [1,3], [2,3], ...]`
The same treatment can also be done for pairs.  One might make the argument that this is preferred in that it puts pairs of the 'best' options first, which would enable a simple slice for disambiugation schemes such as "highest sum pT"

Some profiling studies show that this is about 10x faster than the previous implementation, and about 10x slower (only!) than a numba implementation, although a fair portion of the time is spent in the infamous  `offsets2parents` call.  For extra fun I tried a numba-ized integer sqrt algorithm, and the results were terrible, probably because my laptop's CPU can do FPU sqrt better.