### PR TITLE
Add float32 signatures to numba njits

### DIFF
--- a/awkward-numba/awkward/numba/array/jagged.py
+++ b/awkward-numba/awkward/numba/array/jagged.py
@@ -43,7 +43,7 @@ def _offsets2parents_fill(offsets, parents):
             j += 1
         k += 1
 
-@numba.njit(["void(i8[:], i8[:], f8[:], i8[:])"])
+@numba.njit(["void(i8[:], i8[:], f8[:], i8[:])","void(i8[:], i8[:], f4[:], i8[:])"])
 def _argminmax_fillmin(starts, stops, content, output):
     k = 0
     for i in range(len(starts)):
@@ -57,7 +57,7 @@ def _argminmax_fillmin(starts, stops, content, output):
             output[k] = bestj
             k += 1
 
-@numba.njit(["void(i8[:], i8[:], f8[:], i8[:])"])
+@numba.njit(["void(i8[:], i8[:], f8[:], i8[:])","void(i8[:], i8[:], f4[:], i8[:])"])
 def _argminmax_fillmax(starts, stops, content, output):
     k = 0
     for i in range(len(starts)):


### PR DESCRIPTION
@jpivarski this just adds two common signatures to the njit, I don't think this is too onerous on import (I don't notice it). 