### PR TITLE
implement AwkwardArray.check_prop_valid and AwkwardArray.check_whole_valid

### DIFF
--- a/awkward/array/base.py
+++ b/awkward/array/base.py
@@ -44,7 +44,8 @@ class AwkwardArray(awkward.util.NDArrayOperatorsMixin):
 
     allow_tonumpy = True
     allow_iter = True
-    # TODO for 1.0: add check_prop_valid and check_whole_valid parameters
+    check_prop_valid = True
+    check_whole_valid = True
 
     numpy = numpy
     DEFAULTTYPE = numpy.dtype(numpy.float64)

--- a/awkward/array/chunked.py
+++ b/awkward/array/chunked.py
@@ -95,10 +95,11 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
 
     @chunks.setter
     def chunks(self, value):
-        try:
-            iter(value)
-        except TypeError:
-            raise TypeError("chunks must be iterable")
+        if self.check_prop_valid:
+            try:
+                iter(value)
+            except TypeError:
+                raise TypeError("chunks must be iterable")
         self._chunks = [self._util_toarray(x, self.DEFAULTTYPE) for x in value]
         self._types = [None] * len(self._chunks)
 
@@ -108,11 +109,12 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
 
     @counts.setter
     def counts(self, value):
-        try:
-            if not all(self._util_isinteger(x) and x >= 0 for x in value):
-                raise ValueError("counts must contain only non-negative integers")
-        except TypeError:
-            raise TypeError("counts must be iterable")
+        if self.check_prop_valid:
+            try:
+                if not all(self._util_isinteger(x) and x >= 0 for x in value):
+                    raise ValueError("counts must contain only non-negative integers")
+            except TypeError:
+                raise TypeError("counts must be iterable")
         self._counts = list(value)
         self._offsets = None
 
@@ -131,6 +133,8 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
         return all(x is not None for x in self._types)
 
     def knowcounts(self, until=None):
+        print("knowcounts", until)
+
         if until is None:
             until = len(self._chunks)
         if not 0 <= until <= len(self._chunks):
@@ -264,11 +268,12 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
         return [slice(start, stop) for start, stop in zip(offsets[:-1], offsets[1:])]
 
     def _valid(self):
-        if len(self._counts) > len(self._chunks):
-            raise ValueError("ChunkArray has more counts than chunks")
-        for i, count in enumerate(self._counts):
-            if count != len(self._chunks[i]):
-                raise ValueError("count[{0}] does not agree with len(chunk[{0}])".format(i))
+        if self.check_whole_valid:
+            if len(self._counts) > len(self._chunks):
+                raise ValueError("ChunkArray has more counts than chunks")
+            for i, count in enumerate(self._counts):
+                if count != len(self._chunks[i]):
+                    raise ValueError("count[{0}] does not agree with len(chunk[{0}])".format(i))
         self._gettype({})
 
     def __str__(self):
@@ -587,7 +592,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
 
     def _hasjagged(self):
         for chunkid in range(len(self._chunks)):
-            self.knowcounts(until=chunkid)
+            self.knowcounts(until=(chunkid + 1))
             if self._counts[chunkid] > 0:
                 return self._util_hasjagged(self._chunks[chunkid])
         else:
@@ -720,14 +725,14 @@ class AppendableArray(ChunkedArray):
         if self._util_isinteger(value) and value > 0:
             self._chunkshape = (value,)
         else:
-            try:
-                for x in value:
-                    assert self._util_isinteger(x) and x > 0
-            except TypeError:
-                raise TypeError("chunkshape must be a positive integer or a tuple of integers")
-            except AssertionError:
-                raise ValueError("chunkshape must be a positive integer or tuple of positive integers")
-            else:
+            if self.check_prop_valid:
+                try:
+                    for x in value:
+                        assert self._util_isinteger(x) and x > 0
+                except TypeError:
+                    raise TypeError("chunkshape must be a positive integer or a tuple of integers")
+                except AssertionError:
+                    raise ValueError("chunkshape must be a positive integer or tuple of positive integers")
                 self._chunkshape = tuple(value)
 
     @property
@@ -744,16 +749,18 @@ class AppendableArray(ChunkedArray):
 
     @chunks.setter
     def chunks(self, value):
-        try:
-            iter(value)
-        except TypeError:
-            raise TypeError("chunks must be iterable")
+        if self.check_prop_valid:
+            try:
+                iter(value)
+            except TypeError:
+                raise TypeError("chunks must be iterable")
         chunks = [self._util_toarray(x, self.DEFAULTTYPE, self.numpy.ndarray) for x in value]
-        for chunk in chunks:
-            if chunk.dtype != self._dtype:
-                raise ValueError("cannot assign chunk with dtype ({0}) to an AppendableArray with dtype ({1})".format(chunk.dtype, self._dtype))
-            if chunk.shape[1:] != self._chunkshape[1:]:
-                raise ValueError("cannot assign chunk with dimensionality ({0}) to an AppendableArray with dimensionality ({1}), where dimensionality is shape[1:]".format(chunk.shape[1:], self._chunkshape[1:]))
+        if self.check_prop_valid:
+            for chunk in chunks:
+                if chunk.dtype != self._dtype:
+                    raise ValueError("cannot assign chunk with dtype ({0}) to an AppendableArray with dtype ({1})".format(chunk.dtype, self._dtype))
+                if chunk.shape[1:] != self._chunkshape[1:]:
+                    raise ValueError("cannot assign chunk with dimensionality ({0}) to an AppendableArray with dimensionality ({1}), where dimensionality is shape[1:]".format(chunk.shape[1:], self._chunkshape[1:]))
         self._chunks = chunks
         self._counts = [len(x) for x in self._chunks]
         self._types = [None] * len(self._chunks)
@@ -780,7 +787,8 @@ class AppendableArray(ChunkedArray):
         return sum(self._counts)
 
     def _valid(self):
-        pass
+        if self.check_whole_valid:
+            pass
 
     def __setitem__(self, where, what):
         raise TypeError("array has no Table, cannot assign columns")

--- a/awkward/array/chunked.py
+++ b/awkward/array/chunked.py
@@ -135,8 +135,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
     def knowcounts(self, until=None):
         if until is None:
             until = len(self._chunks)
-        if not 0 <= until <= len(self._chunks):
-            raise ValueError("cannot knowcounts until chunkid {0} with {1} chunks".format(until, len(self._chunks)))
+        until = min(until, len(self._chunks))
         for i in range(len(self._counts), until):
             self._counts.append(len(self._chunks[i]))
 

--- a/awkward/array/chunked.py
+++ b/awkward/array/chunked.py
@@ -133,8 +133,6 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
         return all(x is not None for x in self._types)
 
     def knowcounts(self, until=None):
-        print("knowcounts", until)
-
         if until is None:
             until = len(self._chunks)
         if not 0 <= until <= len(self._chunks):
@@ -460,7 +458,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
 
                 elif self._util_isnumpy(self.type):
                     out = self.numpy.empty((len(head),) + self.type.shape[1:], dtype=self.type.dtype)
-                    self.knowcounts(chunkid.max())
+                    self.knowcounts(chunkid.max() + 1)
                     offsets = self.offsets
 
                     for cid in self.numpy.unique(chunkid):
@@ -592,7 +590,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
 
     def _hasjagged(self):
         for chunkid in range(len(self._chunks)):
-            self.knowcounts(until=(chunkid + 1))
+            self.knowcounts(chunkid + 1)
             if self._counts[chunkid] > 0:
                 return self._util_hasjagged(self._chunks[chunkid])
         else:
@@ -655,7 +653,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
     @property
     def columns(self):
         for chunkid in range(len(self._chunks)):
-            self.knowcounts(until=chunkid)
+            self.knowcounts(chunkid + 1)
             if self._counts[chunkid] > 0:
                 return self._chunks[chunkid].columns
 

--- a/awkward/array/indexed.py
+++ b/awkward/array/indexed.py
@@ -106,10 +106,11 @@ class IndexedArray(awkward.array.base.AwkwardArrayWithContent):
     @index.setter
     def index(self, value):
         value = self._util_toarray(value, self.INDEXTYPE, self.numpy.ndarray)
-        if not self._util_isintegertype(value.dtype.type):
-            raise TypeError("index must have integer dtype")
-        if (value < 0).any():
-            raise ValueError("index must be a non-negative array")
+        if self.check_prop_valid:
+            if not self._util_isintegertype(value.dtype.type):
+                raise TypeError("index must have integer dtype")
+            if (value < 0).any():
+                raise ValueError("index must be a non-negative array")
         self._index = value
         self._inverse = None
         self._isvalid = False
@@ -133,11 +134,12 @@ class IndexedArray(awkward.array.base.AwkwardArrayWithContent):
         return out
 
     def _valid(self):
-        if not self._isvalid:
-            if len(self._index) != 0 and self._index.reshape(-1).max() > len(self._content):
-                raise ValueError("maximum index ({0}) is beyond the length of the content ({1})".format(self._index.reshape(-1).max(), len(self._content)))
+        if self.check_whole_valid:
+            if not self._isvalid:
+                if len(self._index) != 0 and self._index.reshape(-1).max() > len(self._content):
+                    raise ValueError("maximum index ({0}) is beyond the length of the content ({1})".format(self._index.reshape(-1).max(), len(self._content)))
 
-            self._isvalid = True
+                self._isvalid = True
 
     def __iter__(self, checkiter=True):
         if checkiter:
@@ -314,10 +316,11 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
 
     @length.setter
     def length(self, value):
-        if not self._util_isinteger(value):
-            raise TypeError("length must be an integer")
-        if value < 0:
-            raise ValueError("length must be a non-negative integer") 
+        if self.check_prop_valid:
+            if not self._util_isinteger(value):
+                raise TypeError("length must be an integer")
+            if value < 0:
+                raise ValueError("length must be a non-negative integer") 
         self._length = value
 
     @property
@@ -327,14 +330,15 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
     @index.setter
     def index(self, value):
         value = self._util_toarray(value, self.INDEXTYPE, self.numpy.ndarray)
-        if not self._util_isintegertype(value.dtype.type):
-            raise TypeError("index must have integer dtype")
-        if len(value.shape) != 1:
-            raise ValueError("index must be one-dimensional")
-        if (value < 0).any():
-            raise ValueError("index must be a non-negative array")
-        if len(value) > 0 and not (value[1:] >= value[:-1]).all():
-            raise ValueError("index must be monatonically increasing")
+        if self.check_prop_valid:
+            if not self._util_isintegertype(value.dtype.type):
+                raise TypeError("index must have integer dtype")
+            if len(value.shape) != 1:
+                raise ValueError("index must be one-dimensional")
+            if (value < 0).any():
+                raise ValueError("index must be a non-negative array")
+            if len(value) > 0 and not (value[1:] >= value[:-1]).all():
+                raise ValueError("index must be monatonically increasing")
         self._index = value
         self._inverse = None
         self._isvalid = False
@@ -376,11 +380,12 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
         return self._length
 
     def _valid(self):
-        if not self._isvalid:
-            if len(self._index) > len(self._content):
-                raise ValueError("length of index ({0}) must not be greater than the length of content ({1})".format(len(self._index), len(self._content)))
+        if self.check_whole_valid:
+            if not self._isvalid:
+                if len(self._index) > len(self._content):
+                    raise ValueError("length of index ({0}) must not be greater than the length of content ({1})".format(len(self._index), len(self._content)))
 
-            self._isvalid = True
+                self._isvalid = True
 
     def __iter__(self, checkiter=True):
         if checkiter:

--- a/awkward/array/objects.py
+++ b/awkward/array/objects.py
@@ -141,8 +141,9 @@ class ObjectArray(awkward.array.base.AwkwardArrayWithContent):
 
     @generator.setter
     def generator(self, value):
-        if not callable(value):
-            raise TypeError("generator must be a callable (of one argument: the array slice)")
+        if self.check_prop_valid:
+            if not callable(value):
+                raise TypeError("generator must be a callable (of one argument: the array slice)")
         self._generator = value
 
     @property
@@ -161,8 +162,9 @@ class ObjectArray(awkward.array.base.AwkwardArrayWithContent):
 
     @kwargs.setter
     def kwargs(self, value):
-        if not isinstance(value, dict):
-            raise TypeError("kwargs must be a dict")
+        if self.check_prop_valid:
+            if not isinstance(value, dict):
+                raise TypeError("kwargs must be a dict")
         self._kwargs = dict(value)
 
     def __len__(self):
@@ -172,7 +174,8 @@ class ObjectArray(awkward.array.base.AwkwardArrayWithContent):
         return self._generator
 
     def _valid(self):
-        pass
+        if self.check_whole_valid:
+            pass
         
     def __iter__(self, checkiter=True):
         if checkiter:

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -250,8 +250,9 @@ class Table(awkward.array.base.AwkwardArray):
 
     @rowname.setter
     def rowname(self, value):
-        if not isinstance(value, awkward.util.string):
-            raise TypeError("rowname must be a string")
+        if self.check_prop_valid:
+            if not isinstance(value, awkward.util.string):
+                raise TypeError("rowname must be a string")
         self._rowname = value
 
     @classmethod
@@ -368,8 +369,9 @@ class Table(awkward.array.base.AwkwardArray):
 
     @contents.setter
     def contents(self, value):
-        if not isinstance(value, dict) or not all(isinstance(n, awkward.util.string) for n in value):
-            raise TypeError("contents must be a dict from strings to arrays")
+        if self.check_prop_valid:
+            if not isinstance(value, dict) or not all(isinstance(n, awkward.util.string) for n in value):
+                raise TypeError("contents must be a dict from strings to arrays")
         for n in list(value):
             value[n] = self._util_toarray(value[n], self.DEFAULTTYPE)
         self._contents = value
@@ -503,7 +505,8 @@ class Table(awkward.array.base.AwkwardArray):
                 raise TypeError("cannot interpret dtype {0} as a fancy index or mask".format(head.dtype))
 
     def _valid(self):
-        pass
+        if self.check_whole_valid:
+            pass
 
     def __iter__(self, checkiter=True):
         if checkiter:

--- a/awkward/array/virtual.py
+++ b/awkward/array/virtual.py
@@ -162,8 +162,9 @@ class VirtualArray(awkward.array.base.AwkwardArray):
 
     @generator.setter
     def generator(self, value):
-        if not callable(value):
-            raise TypeError("generator must be a callable")
+        if self.check_prop_valid:
+            if not callable(value):
+                raise TypeError("generator must be a callable")
         self._generator = value
 
 
@@ -183,8 +184,9 @@ class VirtualArray(awkward.array.base.AwkwardArray):
 
     @kwargs.setter
     def kwargs(self, value):
-        if not isinstance(value, dict):
-            raise TypeError("kwargs must be a dict")
+        if self.check_prop_valid:
+            if not isinstance(value, dict):
+                raise TypeError("kwargs must be a dict")
         self._kwargs = dict(value)
 
     @property
@@ -193,8 +195,9 @@ class VirtualArray(awkward.array.base.AwkwardArray):
 
     @cache.setter
     def cache(self, value):
-        if not value is None and not (callable(getattr(value, "__getitem__", None)) and callable(getattr(value, "__setitem__", None)) and callable(getattr(value, "__delitem__", None))):
-            raise TypeError("cache must be None, a dict, or have __getitem__/__setitem__/__delitem__ methods")
+        if self.check_prop_valid:
+            if not value is None and not (callable(getattr(value, "__getitem__", None)) and callable(getattr(value, "__setitem__", None)) and callable(getattr(value, "__delitem__", None))):
+                raise TypeError("cache must be None, a dict, or have __getitem__/__setitem__/__delitem__ methods")
         self._cache = value
 
     @property
@@ -203,8 +206,9 @@ class VirtualArray(awkward.array.base.AwkwardArray):
 
     @persistentkey.setter
     def persistentkey(self, value):
-        if value is not None and not isinstance(value, awkward.util.string):
-            raise TypeError("persistentkey must be None or a string")
+        if self.check_prop_valid:
+            if value is not None and not isinstance(value, awkward.util.string):
+                raise TypeError("persistentkey must be None or a string")
         self._persistentkey = value
 
     @property
@@ -213,8 +217,9 @@ class VirtualArray(awkward.array.base.AwkwardArray):
 
     @persistvirtual.setter
     def persistvirtual(self, value):
-        if not isinstance(value, (bool, self.numpy.bool_, self.numpy.bool)):
-            raise TypeError("persistvirtual must be boolean")
+        if self.check_prop_valid:
+            if not isinstance(value, (bool, self.numpy.bool_, self.numpy.bool)):
+                raise TypeError("persistvirtual must be boolean")
         self._persistvirtual = bool(value)
 
     def _gettype(self, seen):
@@ -232,15 +237,17 @@ class VirtualArray(awkward.array.base.AwkwardArray):
 
     @type.setter
     def type(self, value):
-        if value is not None and not isinstance(value, awkward.type.ArrayType):
-            raise TypeError("type must be None or an awkward type (to set Numpy parameters, use awkward.util.fromnumpy(shape, dtype, masked=False))")
+        if self.check_prop_valid:
+            if value is not None and not isinstance(value, awkward.type.ArrayType):
+                raise TypeError("type must be None or an awkward type (to set Numpy parameters, use awkward.util.fromnumpy(shape, dtype, masked=False))")
         self._type = value
 
     def __len__(self):
         return self.shape[0]
 
     def _valid(self):
-        pass
+        if self.check_whole_valid:
+            pass
 
     @property
     def key(self):

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division
+
 import unittest
 import numbers
 import operator


### PR DESCRIPTION
@lgray This is the global switch to turn off all property checks (probably minor) and validity checks (likely a significant performance cost).

```python
import awkward.array.base
awkward.array.base.AwkwardArray.check_prop_valid = False
awkward.array.base.AwkwardArray.check_whole_valid = False
```
It was also one of the features [promised in the specification](https://github.com/scikit-hep/awkward-array/blob/master/specification.adoc#global-switches-and-types) but not implemented until now.
