### PR TITLE
Convert awkward arrays to Arrow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
       - python-setuptools
 
 script:
-  python setup.py pytest
+  pytest -v tests
 
 install:
   - pip install --upgrade setuptools_scm

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION = pypy* ]] ; then pip install "numpy<1.16.0" ; fi       # FIXME: pypy bug in numpy
   - python -c 'import numpy; print(numpy.__version__)'
   - pip install pytest pytest-runner
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install h5py ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install h5py pyarrow ; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install numba ; ln -s ../awkward-numba/awkward/numba awkward/numba ; fi
   - pip install uproot-methods
   - python -c 'import uproot_methods; print(uproot_methods.__version__)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ install:
   - pip install pytest pytest-runner
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install h5py ; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install numba ; ln -s ../awkward-numba/awkward/numba awkward/numba ; fi
+  - pip install uproot-methods
+  - python -c 'import uproot_methods; print(uproot_methods.__version__)'
+  - python -c 'import awkward; print(awkward.__version__)'
   - export AWKWARD_DEPLOYMENT=base
   - pip install --upgrade pyOpenSSL     # for deployment
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,5 +45,7 @@ install:
 
 build_script:
   - "pip install %NUMPY%"
-  - "pip install pytest pytest-runner h5py"
+  - "pip install pytest pytest-runner h5py uproot-methods"
+  - "python -c \"import uproot_methods; print(uproot_methods.__version__)\""
+  - "python -c \"import awkward; print(awkward.__version__)\""
   - "python setup.py pytest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,4 +48,4 @@ build_script:
   - "pip install pytest pytest-runner h5py uproot-methods"
   - "python -c \"import uproot_methods; print(uproot_methods.__version__)\""
   - "python -c \"import awkward; print(awkward.__version__)\""
-  - "python setup.py pytest"
+  - "pytest -v tests"

--- a/awkward/__init__.py
+++ b/awkward/__init__.py
@@ -47,9 +47,11 @@ from awkward.generate import fromiter, fromiterchunks
 
 from awkward.persist import serialize, deserialize, save, load, hdf5
 
+from awkward.arrow import toarrow, fromarrow, toparquet, fromparquet
+
 # convenient access to the version number
 from awkward.version import __version__
 
-__all__ = ["numpy", "ChunkedArray", "AppendableArray", "IndexedArray", "SparseArray", "JaggedArray", "MaskedArray", "BitMaskedArray", "IndexedMaskedArray", "Methods", "ObjectArray", "Table", "UnionArray", "VirtualArray", "StringArray", "fromiter", "fromiterchunks", "serialize", "deserialize", "save", "load", "hdf5", "__version__"]
+__all__ = ["numpy", "ChunkedArray", "AppendableArray", "IndexedArray", "SparseArray", "JaggedArray", "MaskedArray", "BitMaskedArray", "IndexedMaskedArray", "Methods", "ObjectArray", "Table", "UnionArray", "VirtualArray", "StringArray", "fromiter", "fromiterchunks", "serialize", "deserialize", "save", "load", "hdf5", "toarrow", "fromarrow", "toparquet", "fromparquet", "__version__"]
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -1123,6 +1123,33 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         self._valid()
         return self.offsetsaliased(self._starts, self._stops) or (len(self._starts.shape) == 1 and self.numpy.array_equal(self._starts[1:], self._stops[:-1]))
 
+    @property
+    def iscompact(self):
+        if len(self._starts) == 0:
+            return True
+        else:
+            flatstarts = self._starts.reshape(-1)
+            flatstops = self.stops.reshape(-1)   # no underscore!
+            if not self.offsetsaliased(self._starts, self._stops) and not self.numpy.array_equal(flatstarts[1:], flatstops[:-1]):
+                return False
+            if not self._isvalid and not (flatstops >= flatstarts).all():
+                raise ValueError("offsets must be monatonically increasing")
+            return True
+
+    def compact(self):
+        if self.iscompact:
+            return self
+        else:
+            offsets = self.counts2offsets(self.counts.reshape(-1))
+            if len(self._starts.shape) == 1:
+                tmp = self
+            else:                                                # no underscore!
+                tmp = self.JaggedArray(self._starts.reshape(-1), self.stops.reshape(-1), self._content)
+            out = tmp._tojagged(offsets[:-1], offsets[1:], copy=False)
+            out.starts.shape = self._starts.shape
+            out.stops.shape = self._starts.shape  # intentional: self._stops can too long
+            return out
+
     def flatten(self, axis=0):
         if not self._util_isinteger(axis) or axis < 0:
             raise TypeError("axis must be a non-negative integer (can't count from the end)")

--- a/awkward/array/objects.py
+++ b/awkward/array/objects.py
@@ -568,3 +568,29 @@ class StringArray(StringMethods, ObjectArray):
         else:
             out = self._content[where]
             return self.__class__(out.starts, out.stops, out.content, self.encoding)
+
+    @property
+    def iscompact(self):
+        return self._content.iscompact
+
+    def compact(self):
+        return self.fromjagged(self._content.compact(), self.encoding)
+
+    def flatten(self):
+        return self.fromjagged(self._content.flatten(), self.encoding)
+
+    @awkward.util.bothmethod
+    def concatenate(isclassmethod, cls_or_self, arrays, axis=0):
+        if isclassmethod: 
+            cls = cls_or_self
+            if not all(isinstance(x, StringArray) for x in arrays):
+                raise TypeError("cannot concatenate non-StringArrays with StringArray.concatenate")
+        else:
+            self = cls_or_self
+            cls = self.__class__
+            if not isinstance(self, StringArray) or not all(isinstance(x, StringArray) for x in arrays):
+                raise TypeError("cannot concatenate non-StringArrays with StringArrays.concatenate")
+            arrays = (self,) + tuple(arrays)
+
+        jagged = self.JaggedArray.concatenate([x._content for x in arrays], axis=axis)
+        return self.fromjagged(jagged, self.encoding)

--- a/awkward/array/union.py
+++ b/awkward/array/union.py
@@ -121,7 +121,23 @@ class UnionArray(awkward.array.base.AwkwardArray):
     @tags.setter
     def tags(self, value):
         value = self._util_toarray(value, self.TAGTYPE, self.numpy.ndarray)
+        tagsmax = value.max()
+        if tagsmax <= self.numpy.iinfo(self.TAGTYPE).max:
+            value = value.astype(self.TAGTYPE)
+        elif tagsmax <= self.numpy.iinfo(self.numpy.uint8).max:
+            value = value.astype(self.numpy.uint8)
+        elif tagsmax <= self.numpy.iinfo(self.numpy.uint16).max:
+            value = value.astype(self.numpy.uint16)
+        elif tagsmax <= self.numpy.iinfo(self.numpy.uint32).max:
+            value = value.astype(self.numpy.uint32)
+        elif tagsmax <= self.numpy.iinfo(self.numpy.uint64).max:
+            value = value.astype(self.numpy.uint64)
+        else:
+            raise ValueError("maximum tag must be at most {0}".format(self.numpy.iinfo(self.numpy.uint64).max))
+
         if self.check_prop_valid:
+            if len(value) == 0:
+                raise ValueError("tags must be non-empty")
             if not self._util_isintegertype(value.dtype.type):
                 raise TypeError("tags must have integer dtype")
             if (value < 0).any():

--- a/awkward/arrow.py
+++ b/awkward/arrow.py
@@ -40,6 +40,8 @@ import awkward.array.virtual
 import awkward.type
 import awkward.util
 
+################################################################################ type conversions
+
 def schema2type(schema):
     import pyarrow
 
@@ -123,7 +125,12 @@ def schema2type(schema):
 
     return out
 
-def view(obj, awkwardlib=None):
+################################################################################ value conversions
+
+def toarrow(obj):
+    raise NotImplementedError
+
+def fromarrow(obj, awkwardlib=None):
     import pyarrow
     awkwardlib = awkward.util.awkwardlib(awkwardlib)
     ARROW_BITMASKTYPE = awkwardlib.numpy.uint8
@@ -271,7 +278,12 @@ def view(obj, awkwardlib=None):
     else:
         raise NotImplementedError(type(obj))
 
-class ParquetFile(object):
+################################################################################ Parquet file handling
+
+def toparquet(obj):
+    raise NotImplementedError
+
+class _ParquetFile(object):
     def __init__(self, file, cache=None, metadata=None, common_metadata=None):
         self.file = file
         self.cache = cache
@@ -281,7 +293,7 @@ class ParquetFile(object):
 
     def _init(self):
         import pyarrow.parquet
-        self.parquetfile = pyarrow.parquet.ParquetFile(self.file, metadata=self.metadata, common_metadata=self.common_metadata)
+        self.parquetfile = pyarrow.parquet._ParquetFile(self.file, metadata=self.metadata, common_metadata=self.common_metadata)
         self.type = schema2type(self.parquetfile.schema.to_arrow_schema())
         
     def __getstate__(self):
@@ -304,10 +316,10 @@ class ParquetFile(object):
     @classmethod
     def fromjson(cls, state):
         return cls(state["file"], cache=None, metadata=state["metadata"], common_metadata=state["common_metadata"])
-        
+
 def fromparquet(file, awkwardlib=None, cache=None, persistvirtual=False, metadata=None, common_metadata=None):
     awkwardlib = awkward.util.awkwardlib(awkwardlib)
-    parquetfile = ParquetFile(file, cache=cache, metadata=metadata, common_metadata=common_metadata)
+    parquetfile = _ParquetFile(file, cache=cache, metadata=metadata, common_metadata=common_metadata)
     columns = parquetfile.type.columns
 
     chunks = []

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -62,7 +62,7 @@ whitelist = [["awkward.util", "frombuffer"],
              ["awkward", "Table"],
              ["awkward", "numpy", "frombuffer"],
              ["awkward.persist", "*"],
-             ["awkward.arrow", "ParquetFile", "fromjson"]]
+             ["awkward.arrow", "_ParquetFile", "fromjson"]]
 
 def frompython(obj):
     return base64.b64encode(pickle.dumps(obj)).decode("ascii")

--- a/awkward/type.py
+++ b/awkward/type.py
@@ -552,7 +552,17 @@ class OptionType(Type):
 
     @property
     def dtype(self):
-        return self._type.dtype
+        if isinstance(self._type, Type):
+            return self._type.dtype
+
+        elif isinstance(self._type, numpy.dtype):
+            if self._type.subdtype is None:
+                return self._type
+            else:
+                return self._type.subdtype[0]
+
+        else:
+            return numpy.dtype(object)
 
     def _isnumpy(self, seen):
         if id(self) in seen:

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -44,6 +44,24 @@ class Test(unittest.TestCase):
     def runTest(self):
         pass
 
+    def test_arrow_toarrow(self):
+        try:
+            import uproot_methods
+        except ImportError:
+            pytest.skip("unable to import uproot_methods")
+        else:
+            jet_m   = awkward.fromiter([[60.0, 70.0, 80.0], [], [90.0, 100.0]])
+            jet_pt  = awkward.fromiter([[10.0, 20.0, 30.0], [], [40.0, 50.0]])
+            jet_eta = awkward.fromiter([[-3.0, -2.0, 2.0],  [], [-1.0, 1.0]])
+            jet_phi = awkward.fromiter([[-1.5,  0.0, 1.5],  [], [0.78, -0.78]])
+            jets    = uproot_methods.TLorentzVectorArray.from_ptetaphim(jet_pt, jet_eta, jet_phi, jet_m)
+
+            assert list(awkward.arrow.toarrow(jets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": 40.0, "fEta": -1.0, "fPhi": 0.78, "fMass": 90.0}, {"fPt": 50.0, "fEta": 1.0, "fPhi": -0.78, "fMass": 100.0}]]
+
+            # FIXME: it might be possible to avoid this "mask push-down" in Arrow, but I don't know how
+            maskedjets = awkward.MaskedArray([False, False, True], jets, maskedwhen=True)
+            assert list(awkward.arrow.toarrow(maskedjets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": None, "fEta": None, "fPhi": None, "fMass": None}, {"fPt": None, "fEta": None, "fPhi": None, "fMass": None}]]
+
     def test_arrow_array(self):
         if pyarrow is not None:
             a = pyarrow.array([1.1, 2.2, 3.3, 4.4, 5.5])

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -30,6 +30,8 @@
 
 import unittest
 
+import pytest
+
 import numpy
 try:
     import pyarrow
@@ -63,197 +65,275 @@ class Test(unittest.TestCase):
             assert list(awkward.arrow.toarrow(maskedjets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": None, "fEta": None, "fPhi": None, "fMass": None}, {"fPt": None, "fEta": None, "fPhi": None, "fMass": None}]]
 
     def test_arrow_array(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([1.1, 2.2, 3.3, 4.4, 5.5])
             assert awkward.arrow.fromarrow(a).tolist() == [1.1, 2.2, 3.3, 4.4, 5.5]
 
     def test_arrow_boolean(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([True, True, False, False, True])
             assert awkward.arrow.fromarrow(a).tolist() == [True, True, False, False, True]
 
     def test_arrow_array_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([1.1, 2.2, 3.3, None, 4.4, 5.5])
             assert awkward.arrow.fromarrow(a).tolist() == [1.1, 2.2, 3.3, None, 4.4, 5.5]
 
     def test_arrow_nested_array(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
             assert awkward.arrow.fromarrow(a).tolist() == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 
     def test_arrow_nested_nested_array(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[[1.1, 2.2], [3.3], []], [], [[4.4, 5.5]]])
             assert awkward.arrow.fromarrow(a).tolist() == [[[1.1, 2.2], [3.3], []], [], [[4.4, 5.5]]]
 
     def test_arrow_nested_array_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[1.1, 2.2, None], [], [4.4, 5.5]])
             assert awkward.arrow.fromarrow(a).tolist() == [[1.1, 2.2, None], [], [4.4, 5.5]]
 
     def test_arrow_null_nested_array_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[1.1, 2.2, None], [], None, [4.4, 5.5]])
             assert awkward.arrow.fromarrow(a).tolist() == [[1.1, 2.2, None], [], None, [4.4, 5.5]]
 
     def test_arrow_chunked_array(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.chunked_array([pyarrow.array([1.1, 2.2, 3.3, 4.4, 5.5]), pyarrow.array([]), pyarrow.array([6.6, 7.7, 8.8])])
             assert awkward.arrow.fromarrow(a).tolist() == [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
 
     def test_arrow_struct(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
 
     def test_arrow_struct_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}]
 
     def test_arrow_null_struct(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([{"x": 1, "y": 1.1}, None, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, None, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
 
     def test_arrow_null_struct_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([{"x": 1, "y": 1.1}, None, {"x": 2, "y": None}, {"x": 3, "y": 3.3}])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, None, {"x": 2, "y": None}, {"x": 3, "y": 3.3}]
 
     def test_arrow_chunked_struct(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.chunked_array([pyarrow.array([{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]), pyarrow.array([]), pyarrow.array([{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}])])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}, {"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]
 
     def test_arrow_nested_struct(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
             assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_nested_struct_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
             assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_null_nested_struct(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
             assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_null_nested_struct_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
             assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_struct_nested(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}]
 
     def test_arrow_struct_nested_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}])
             assert awkward.arrow.fromarrow(a).tolist() == [{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}]
 
     def test_arrow_nested_struct_nested(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}], [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]])
             assert awkward.arrow.fromarrow(a).tolist() == [[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}], [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]]
 
     def test_arrow_null_nested_struct_nested_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}], None, [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]])
             assert awkward.arrow.fromarrow(a).tolist() == [[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}], None, [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]]
 
     def test_arrow_strings(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array(["one", "two", "three", u"fo\u2014ur", "five"])
             assert awkward.arrow.fromarrow(a).tolist() == ["one", "two", "three", u"fo\u2014ur", "five"]
 
     def test_arrow_strings_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array(["one", "two", None, u"fo\u2014ur", "five"])
             assert awkward.arrow.fromarrow(a).tolist() == ["one", "two", None, u"fo\u2014ur", "five"]
 
     def test_arrow_binary(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([b"one", b"two", b"three", b"four", b"five"])
             assert awkward.arrow.fromarrow(a).tolist() == [b"one", b"two", b"three", b"four", b"five"]
 
     def test_arrow_binary_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([b"one", b"two", None, b"four", b"five"])
             assert awkward.arrow.fromarrow(a).tolist() == [b"one", b"two", None, b"four", b"five"]
 
     def test_arrow_chunked_strings(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.chunked_array([pyarrow.array(["one", "two", "three", "four", "five"]), pyarrow.array(["six", "seven", "eight"])])
             assert awkward.arrow.fromarrow(a).tolist() == ["one", "two", "three", "four", "five", "six", "seven", "eight"]
 
     def test_arrow_nested_strings(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([["one", "two", "three"], [], ["four", "five"]])
             assert awkward.arrow.fromarrow(a).tolist() == [["one", "two", "three"], [], ["four", "five"]]
 
     def test_arrow_nested_strings_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([["one", "two", None], [], ["four", "five"]])
             assert awkward.arrow.fromarrow(a).tolist() == [["one", "two", None], [], ["four", "five"]]
 
     def test_arrow_null_nested_strings_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.array([["one", "two", None], [], None, ["four", "five"]])
             assert awkward.arrow.fromarrow(a).tolist() == [["one", "two", None], [], None, ["four", "five"]]
 
     def test_arrow_union_sparse(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.UnionArray.from_sparse(pyarrow.array([0, 1, 0, 0, 1], type=pyarrow.int8()), [pyarrow.array([0.0, 1.1, 2.2, 3.3, 4.4]), pyarrow.array([True, True, False, True, False])])
             assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 2.2, 3.3, False]
 
     def test_arrow_union_sparse_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.UnionArray.from_sparse(pyarrow.array([0, 1, 0, 0, 1], type=pyarrow.int8()), [pyarrow.array([0.0, 1.1, None, 3.3, 4.4]), pyarrow.array([True, True, False, True, False])])
             assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, None, 3.3, False]
 
     def test_arrow_union_sparse_null_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.UnionArray.from_sparse(pyarrow.array([0, 1, 0, 0, 1], type=pyarrow.int8()), [pyarrow.array([0.0, 1.1, None, 3.3, 4.4]), pyarrow.array([True, None, False, True, False])])
             assert awkward.arrow.fromarrow(a).tolist() == [0.0, None, None, 3.3, False]
 
     def test_arrow_union_dense(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.UnionArray.from_dense(pyarrow.array([0, 1, 0, 0, 0, 1, 1], type=pyarrow.int8()), pyarrow.array([0, 0, 1, 2, 3, 1, 2], type=pyarrow.int32()), [pyarrow.array([0.0, 1.1, 2.2, 3.3]), pyarrow.array([True, True, False])])
             assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 1.1, 2.2, 3.3, True, False]
 
     def test_arrow_union_dense_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.UnionArray.from_dense(pyarrow.array([0, 1, 0, 0, 0, 1, 1], type=pyarrow.int8()), pyarrow.array([0, 0, 1, 2, 3, 1, 2], type=pyarrow.int32()), [pyarrow.array([0.0, 1.1, None, 3.3]), pyarrow.array([True, True, False])])
             assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 1.1, None, 3.3, True, False]
 
     def test_arrow_union_dense_null_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.UnionArray.from_dense(pyarrow.array([0, 1, 0, 0, 0, 1, 1], type=pyarrow.int8()), pyarrow.array([0, 0, 1, 2, 3, 1, 2], type=pyarrow.int32()), [pyarrow.array([0.0, 1.1, None, 3.3]), pyarrow.array([True, None, False])])
             assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 1.1, None, 3.3, None, False]
 
     def test_arrow_dictarray(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.DictionaryArray.from_arrays(pyarrow.array([0, 0, 2, 2, 1, 0, 2, 1, 1]), pyarrow.array(["one", "two", "three"]))
             assert awkward.arrow.fromarrow(a).tolist() == ["one", "one", "three", "three", "two", "one", "three", "two", "two"]
 
     def test_arrow_dictarray_null(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.DictionaryArray.from_arrays(pyarrow.array([0, 0, 2, None, 1, None, 2, 1, 1]), pyarrow.array(["one", "two", "three"]))
             assert awkward.arrow.fromarrow(a).tolist() == ["one", "one", "three", None, "two", None, "three", "two", "two"]
 
     def test_arrow_null_dictarray(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.DictionaryArray.from_arrays(pyarrow.array([0, 0, 2, 2, 1, 0, 2, 1, 1]), pyarrow.array(["one", None, "three"]))
             assert awkward.arrow.fromarrow(a).tolist() == ["one", "one", "three", "three", None, "one", "three", None, None]
 
     def test_arrow_batch(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.RecordBatch.from_arrays(
                 [pyarrow.array([1.1, 2.2, 3.3, None, 5.5]),
                  pyarrow.array([[1, 2, 3], [], [4, 5], [None], [6]]),
@@ -264,7 +344,9 @@ class Test(unittest.TestCase):
             assert awkward.arrow.fromarrow(a).tolist() == [{"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d":{"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}]
 
     def test_arrow_table(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = pyarrow.Table.from_batches([
                 pyarrow.RecordBatch.from_arrays(
                 [pyarrow.array([1.1, 2.2, 3.3, None, 5.5]),
@@ -283,7 +365,9 @@ class Test(unittest.TestCase):
             assert awkward.arrow.fromarrow(a).tolist() == [{"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d": {"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}, {"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d": {"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}]
 
     def test_arrow_nonnullable_table(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             x = pyarrow.array([1, 2, 3])
             y = pyarrow.array([1.1, 2.2, 3.3])
             table = pyarrow.Table.from_arrays([x], ["x"])
@@ -291,7 +375,9 @@ class Test(unittest.TestCase):
             assert awkward.arrow.fromarrow(table2).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
 
     # def test_arrow_writeparquet(self):
-    #     if pyarrow is not None:
+    #     if pyarrow is None:
+    #         pytest.skip("unable to import pyarrow")
+    #     else:
     #         a = pyarrow.Table.from_batches([
     #             pyarrow.RecordBatch.from_arrays(
     #             [pyarrow.array([1.1, 2.2, 3.3, None, 5.5]),
@@ -309,7 +395,9 @@ class Test(unittest.TestCase):
     #         writer.close()
 
     def test_arrow_readparquet(self):
-        if pyarrow is not None:
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
             a = awkward.arrow.fromparquet("tests/samples/features-0_11_1.parquet", persistvirtual=True)
             assert a["a"].tolist() == [1.1, 2.2, 3.3, None, 5.5, 2.2, 1.1, 3.3, None, 5.5, 1.1, 2.2, 3.3, None, 5.5, 2.2, 1.1, 3.3, None, 5.5]
             storage = {}

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -47,192 +47,192 @@ class Test(unittest.TestCase):
     def test_arrow_array(self):
         if pyarrow is not None:
             a = pyarrow.array([1.1, 2.2, 3.3, 4.4, 5.5])
-            assert awkward.arrow.view(a).tolist() == [1.1, 2.2, 3.3, 4.4, 5.5]
+            assert awkward.arrow.fromarrow(a).tolist() == [1.1, 2.2, 3.3, 4.4, 5.5]
 
     def test_arrow_boolean(self):
         if pyarrow is not None:
             a = pyarrow.array([True, True, False, False, True])
-            assert awkward.arrow.view(a).tolist() == [True, True, False, False, True]
+            assert awkward.arrow.fromarrow(a).tolist() == [True, True, False, False, True]
 
     def test_arrow_array_null(self):
         if pyarrow is not None:
             a = pyarrow.array([1.1, 2.2, 3.3, None, 4.4, 5.5])
-            assert awkward.arrow.view(a).tolist() == [1.1, 2.2, 3.3, None, 4.4, 5.5]
+            assert awkward.arrow.fromarrow(a).tolist() == [1.1, 2.2, 3.3, None, 4.4, 5.5]
 
     def test_arrow_nested_array(self):
         if pyarrow is not None:
             a = pyarrow.array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
-            assert awkward.arrow.view(a).tolist() == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 
     def test_arrow_nested_nested_array(self):
         if pyarrow is not None:
             a = pyarrow.array([[[1.1, 2.2], [3.3], []], [], [[4.4, 5.5]]])
-            assert awkward.arrow.view(a).tolist() == [[[1.1, 2.2], [3.3], []], [], [[4.4, 5.5]]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[[1.1, 2.2], [3.3], []], [], [[4.4, 5.5]]]
 
     def test_arrow_nested_array_null(self):
         if pyarrow is not None:
             a = pyarrow.array([[1.1, 2.2, None], [], [4.4, 5.5]])
-            assert awkward.arrow.view(a).tolist() == [[1.1, 2.2, None], [], [4.4, 5.5]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[1.1, 2.2, None], [], [4.4, 5.5]]
 
     def test_arrow_null_nested_array_null(self):
         if pyarrow is not None:
             a = pyarrow.array([[1.1, 2.2, None], [], None, [4.4, 5.5]])
-            assert awkward.arrow.view(a).tolist() == [[1.1, 2.2, None], [], None, [4.4, 5.5]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[1.1, 2.2, None], [], None, [4.4, 5.5]]
 
     def test_arrow_chunked_array(self):
         if pyarrow is not None:
             a = pyarrow.chunked_array([pyarrow.array([1.1, 2.2, 3.3, 4.4, 5.5]), pyarrow.array([]), pyarrow.array([6.6, 7.7, 8.8])])
-            assert awkward.arrow.view(a).tolist() == [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
+            assert awkward.arrow.fromarrow(a).tolist() == [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
 
     def test_arrow_struct(self):
         if pyarrow is not None:
             a = pyarrow.array([{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}])
-            assert awkward.arrow.view(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
 
     def test_arrow_struct_null(self):
         if pyarrow is not None:
             a = pyarrow.array([{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}])
-            assert awkward.arrow.view(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}]
 
     def test_arrow_null_struct(self):
         if pyarrow is not None:
             a = pyarrow.array([{"x": 1, "y": 1.1}, None, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}])
-            assert awkward.arrow.view(a).tolist() == [{"x": 1, "y": 1.1}, None, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, None, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
 
     def test_arrow_null_struct_null(self):
         if pyarrow is not None:
             a = pyarrow.array([{"x": 1, "y": 1.1}, None, {"x": 2, "y": None}, {"x": 3, "y": 3.3}])
-            assert awkward.arrow.view(a).tolist() == [{"x": 1, "y": 1.1}, None, {"x": 2, "y": None}, {"x": 3, "y": 3.3}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, None, {"x": 2, "y": None}, {"x": 3, "y": 3.3}]
 
     def test_arrow_chunked_struct(self):
         if pyarrow is not None:
             a = pyarrow.chunked_array([pyarrow.array([{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]), pyarrow.array([]), pyarrow.array([{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}])])
-            assert awkward.arrow.view(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}, {"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}, {"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]
 
     def test_arrow_nested_struct(self):
         if pyarrow is not None:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
-            assert awkward.arrow.view(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_nested_struct_null(self):
         if pyarrow is not None:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
-            assert awkward.arrow.view(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_null_nested_struct(self):
         if pyarrow is not None:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
-            assert awkward.arrow.view(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_null_nested_struct_null(self):
         if pyarrow is not None:
             a = pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]])
-            assert awkward.arrow.view(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[{"x": 1, "y": 1.1}, {"x": 2, "y": None}, {"x": 3, "y": 3.3}], None, [], [{"x": 4, "y": 4.4}, {"x": 5, "y": 5.5}]]
 
     def test_arrow_struct_nested(self):
         if pyarrow is not None:
             a = pyarrow.array([{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}])
-            assert awkward.arrow.view(a).tolist() == [{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}]
 
     def test_arrow_struct_nested_null(self):
         if pyarrow is not None:
             a = pyarrow.array([{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}])
-            assert awkward.arrow.view(a).tolist() == [{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}]
 
     def test_arrow_nested_struct_nested(self):
         if pyarrow is not None:
             a = pyarrow.array([[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}], [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]])
-            assert awkward.arrow.view(a).tolist() == [[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}], [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [3, 3], "y": 3.3}], [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]]
 
     def test_arrow_null_nested_struct_nested_null(self):
         if pyarrow is not None:
             a = pyarrow.array([[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}], None, [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]])
-            assert awkward.arrow.view(a).tolist() == [[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}], None, [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]]
+            assert awkward.arrow.fromarrow(a).tolist() == [[{"x": [], "y": 1.1}, {"x": [2], "y": 2.2}, {"x": [None, 3], "y": 3.3}], None, [], [{"x": [4, 4, 4], "y": 4.4}, {"x": [5, 5, 5, 5], "y": 5.5}]]
 
     def test_arrow_strings(self):
         if pyarrow is not None:
             a = pyarrow.array(["one", "two", "three", u"fo\u2014ur", "five"])
-            assert awkward.arrow.view(a).tolist() == ["one", "two", "three", u"fo\u2014ur", "five"]
+            assert awkward.arrow.fromarrow(a).tolist() == ["one", "two", "three", u"fo\u2014ur", "five"]
 
     def test_arrow_strings_null(self):
         if pyarrow is not None:
             a = pyarrow.array(["one", "two", None, u"fo\u2014ur", "five"])
-            assert awkward.arrow.view(a).tolist() == ["one", "two", None, u"fo\u2014ur", "five"]
+            assert awkward.arrow.fromarrow(a).tolist() == ["one", "two", None, u"fo\u2014ur", "five"]
 
     def test_arrow_binary(self):
         if pyarrow is not None:
             a = pyarrow.array([b"one", b"two", b"three", b"four", b"five"])
-            assert awkward.arrow.view(a).tolist() == [b"one", b"two", b"three", b"four", b"five"]
+            assert awkward.arrow.fromarrow(a).tolist() == [b"one", b"two", b"three", b"four", b"five"]
 
     def test_arrow_binary_null(self):
         if pyarrow is not None:
             a = pyarrow.array([b"one", b"two", None, b"four", b"five"])
-            assert awkward.arrow.view(a).tolist() == [b"one", b"two", None, b"four", b"five"]
+            assert awkward.arrow.fromarrow(a).tolist() == [b"one", b"two", None, b"four", b"five"]
 
     def test_arrow_chunked_strings(self):
         if pyarrow is not None:
             a = pyarrow.chunked_array([pyarrow.array(["one", "two", "three", "four", "five"]), pyarrow.array(["six", "seven", "eight"])])
-            assert awkward.arrow.view(a).tolist() == ["one", "two", "three", "four", "five", "six", "seven", "eight"]
+            assert awkward.arrow.fromarrow(a).tolist() == ["one", "two", "three", "four", "five", "six", "seven", "eight"]
 
     def test_arrow_nested_strings(self):
         if pyarrow is not None:
             a = pyarrow.array([["one", "two", "three"], [], ["four", "five"]])
-            assert awkward.arrow.view(a).tolist() == [["one", "two", "three"], [], ["four", "five"]]
+            assert awkward.arrow.fromarrow(a).tolist() == [["one", "two", "three"], [], ["four", "five"]]
 
     def test_arrow_nested_strings_null(self):
         if pyarrow is not None:
             a = pyarrow.array([["one", "two", None], [], ["four", "five"]])
-            assert awkward.arrow.view(a).tolist() == [["one", "two", None], [], ["four", "five"]]
+            assert awkward.arrow.fromarrow(a).tolist() == [["one", "two", None], [], ["four", "five"]]
 
     def test_arrow_null_nested_strings_null(self):
         if pyarrow is not None:
             a = pyarrow.array([["one", "two", None], [], None, ["four", "five"]])
-            assert awkward.arrow.view(a).tolist() == [["one", "two", None], [], None, ["four", "five"]]
+            assert awkward.arrow.fromarrow(a).tolist() == [["one", "two", None], [], None, ["four", "five"]]
 
     def test_arrow_union_sparse(self):
         if pyarrow is not None:
             a = pyarrow.UnionArray.from_sparse(pyarrow.array([0, 1, 0, 0, 1], type=pyarrow.int8()), [pyarrow.array([0.0, 1.1, 2.2, 3.3, 4.4]), pyarrow.array([True, True, False, True, False])])
-            assert awkward.arrow.view(a).tolist() == [0.0, True, 2.2, 3.3, False]
+            assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 2.2, 3.3, False]
 
     def test_arrow_union_sparse_null(self):
         if pyarrow is not None:
             a = pyarrow.UnionArray.from_sparse(pyarrow.array([0, 1, 0, 0, 1], type=pyarrow.int8()), [pyarrow.array([0.0, 1.1, None, 3.3, 4.4]), pyarrow.array([True, True, False, True, False])])
-            assert awkward.arrow.view(a).tolist() == [0.0, True, None, 3.3, False]
+            assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, None, 3.3, False]
 
     def test_arrow_union_sparse_null_null(self):
         if pyarrow is not None:
             a = pyarrow.UnionArray.from_sparse(pyarrow.array([0, 1, 0, 0, 1], type=pyarrow.int8()), [pyarrow.array([0.0, 1.1, None, 3.3, 4.4]), pyarrow.array([True, None, False, True, False])])
-            assert awkward.arrow.view(a).tolist() == [0.0, None, None, 3.3, False]
+            assert awkward.arrow.fromarrow(a).tolist() == [0.0, None, None, 3.3, False]
 
     def test_arrow_union_dense(self):
         if pyarrow is not None:
             a = pyarrow.UnionArray.from_dense(pyarrow.array([0, 1, 0, 0, 0, 1, 1], type=pyarrow.int8()), pyarrow.array([0, 0, 1, 2, 3, 1, 2], type=pyarrow.int32()), [pyarrow.array([0.0, 1.1, 2.2, 3.3]), pyarrow.array([True, True, False])])
-            assert awkward.arrow.view(a).tolist() == [0.0, True, 1.1, 2.2, 3.3, True, False]
+            assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 1.1, 2.2, 3.3, True, False]
 
     def test_arrow_union_dense_null(self):
         if pyarrow is not None:
             a = pyarrow.UnionArray.from_dense(pyarrow.array([0, 1, 0, 0, 0, 1, 1], type=pyarrow.int8()), pyarrow.array([0, 0, 1, 2, 3, 1, 2], type=pyarrow.int32()), [pyarrow.array([0.0, 1.1, None, 3.3]), pyarrow.array([True, True, False])])
-            assert awkward.arrow.view(a).tolist() == [0.0, True, 1.1, None, 3.3, True, False]
+            assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 1.1, None, 3.3, True, False]
 
     def test_arrow_union_dense_null_null(self):
         if pyarrow is not None:
             a = pyarrow.UnionArray.from_dense(pyarrow.array([0, 1, 0, 0, 0, 1, 1], type=pyarrow.int8()), pyarrow.array([0, 0, 1, 2, 3, 1, 2], type=pyarrow.int32()), [pyarrow.array([0.0, 1.1, None, 3.3]), pyarrow.array([True, None, False])])
-            assert awkward.arrow.view(a).tolist() == [0.0, True, 1.1, None, 3.3, None, False]
+            assert awkward.arrow.fromarrow(a).tolist() == [0.0, True, 1.1, None, 3.3, None, False]
 
     def test_arrow_dictarray(self):
         if pyarrow is not None:
             a = pyarrow.DictionaryArray.from_arrays(pyarrow.array([0, 0, 2, 2, 1, 0, 2, 1, 1]), pyarrow.array(["one", "two", "three"]))
-            assert awkward.arrow.view(a).tolist() == ["one", "one", "three", "three", "two", "one", "three", "two", "two"]
+            assert awkward.arrow.fromarrow(a).tolist() == ["one", "one", "three", "three", "two", "one", "three", "two", "two"]
 
     def test_arrow_dictarray_null(self):
         if pyarrow is not None:
             a = pyarrow.DictionaryArray.from_arrays(pyarrow.array([0, 0, 2, None, 1, None, 2, 1, 1]), pyarrow.array(["one", "two", "three"]))
-            assert awkward.arrow.view(a).tolist() == ["one", "one", "three", None, "two", None, "three", "two", "two"]
+            assert awkward.arrow.fromarrow(a).tolist() == ["one", "one", "three", None, "two", None, "three", "two", "two"]
 
     def test_arrow_null_dictarray(self):
         if pyarrow is not None:
             a = pyarrow.DictionaryArray.from_arrays(pyarrow.array([0, 0, 2, 2, 1, 0, 2, 1, 1]), pyarrow.array(["one", None, "three"]))
-            assert awkward.arrow.view(a).tolist() == ["one", "one", "three", "three", None, "one", "three", None, None]
+            assert awkward.arrow.fromarrow(a).tolist() == ["one", "one", "three", "three", None, "one", "three", None, None]
 
     def test_arrow_batch(self):
         if pyarrow is not None:
@@ -243,7 +243,7 @@ class Test(unittest.TestCase):
                  pyarrow.array([{"x": 1, "y": 1.1}, None, None, {"x": 4, "y": None}, {"x": 5, "y": 5.5}]),
                  pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": None}, {"x": 5, "y": 5.5}], [None], [{"x": 6, "y": 6.6}]])],
                 ["a", "b", "c", "d", "e"])
-            assert awkward.arrow.view(a).tolist() == [{"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d":{"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d":{"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}]
 
     def test_arrow_table(self):
         if pyarrow is not None:
@@ -262,7 +262,7 @@ class Test(unittest.TestCase):
                  pyarrow.array([{"x": 1, "y": 1.1}, None, None, {"x": 4, "y": None}, {"x": 5, "y": 5.5}]),
                  pyarrow.array([[{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], [], [{"x": 4, "y": None}, {"x": 5, "y": 5.5}], [None], [{"x": 6, "y": 6.6}]])],
                 ["a", "b", "c", "d", "e"])])
-            assert awkward.arrow.view(a).tolist() == [{"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d": {"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}, {"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d": {"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}]
+            assert awkward.arrow.fromarrow(a).tolist() == [{"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d": {"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}, {"a": 1.1, "b": [1, 2, 3], "c": {"x": 1, "y": 1.1}, "d": {"x": 1, "y": 1.1}, "e": [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]}, {"a": 2.2, "b": [], "c": {"x": 2, "y": 2.2}, "d": None, "e": []}, {"a": 3.3, "b": [4, 5], "c": {"x": 3, "y": 3.3}, "d": None, "e": [{"x": 4, "y": None}, {"x": 5, "y": 5.5}]}, {"a": None, "b": [None], "c": {"x": 4, "y": None}, "d": {"x": 4, "y": None}, "e": [None]}, {"a": 5.5, "b": [6], "c": {"x": 5, "y": 5.5}, "d": {"x": 5, "y": 5.5}, "e": [{"x": 6, "y": 6.6}]}]
 
     def test_arrow_nonnullable_table(self):
         if pyarrow is not None:
@@ -270,7 +270,7 @@ class Test(unittest.TestCase):
             y = pyarrow.array([1.1, 2.2, 3.3])
             table = pyarrow.Table.from_arrays([x], ["x"])
             table2 = table.add_column(1, pyarrow.column(pyarrow.field("y", y.type, False), numpy.array([1.1, 2.2, 3.3])))
-            assert awkward.arrow.view(table2).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
+            assert awkward.arrow.fromarrow(table2).tolist() == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}]
 
     # def test_arrow_writeparquet(self):
     #     if pyarrow is not None:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -47,22 +47,25 @@ class Test(unittest.TestCase):
         pass
 
     def test_arrow_toarrow(self):
-        try:
-            import uproot_methods
-        except ImportError:
-            pytest.skip("unable to import uproot_methods")
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
         else:
-            jet_m   = awkward.fromiter([[60.0, 70.0, 80.0], [], [90.0, 100.0]])
-            jet_pt  = awkward.fromiter([[10.0, 20.0, 30.0], [], [40.0, 50.0]])
-            jet_eta = awkward.fromiter([[-3.0, -2.0, 2.0],  [], [-1.0, 1.0]])
-            jet_phi = awkward.fromiter([[-1.5,  0.0, 1.5],  [], [0.78, -0.78]])
-            jets    = uproot_methods.TLorentzVectorArray.from_ptetaphim(jet_pt, jet_eta, jet_phi, jet_m)
+            try:
+                import uproot_methods
+            except ImportError:
+                pytest.skip("unable to import uproot_methods")
+            else:
+                jet_m   = awkward.fromiter([[60.0, 70.0, 80.0], [], [90.0, 100.0]])
+                jet_pt  = awkward.fromiter([[10.0, 20.0, 30.0], [], [40.0, 50.0]])
+                jet_eta = awkward.fromiter([[-3.0, -2.0, 2.0],  [], [-1.0, 1.0]])
+                jet_phi = awkward.fromiter([[-1.5,  0.0, 1.5],  [], [0.78, -0.78]])
+                jets    = uproot_methods.TLorentzVectorArray.from_ptetaphim(jet_pt, jet_eta, jet_phi, jet_m)
 
-            assert list(awkward.arrow.toarrow(jets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": 40.0, "fEta": -1.0, "fPhi": 0.78, "fMass": 90.0}, {"fPt": 50.0, "fEta": 1.0, "fPhi": -0.78, "fMass": 100.0}]]
+                assert list(awkward.arrow.toarrow(jets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": 40.0, "fEta": -1.0, "fPhi": 0.78, "fMass": 90.0}, {"fPt": 50.0, "fEta": 1.0, "fPhi": -0.78, "fMass": 100.0}]]
 
-            # FIXME: it might be possible to avoid this "mask push-down" in Arrow, but I don't know how
-            maskedjets = awkward.MaskedArray([False, False, True], jets, maskedwhen=True)
-            assert list(awkward.arrow.toarrow(maskedjets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": None, "fEta": None, "fPhi": None, "fMass": None}, {"fPt": None, "fEta": None, "fPhi": None, "fMass": None}]]
+                # FIXME: it might be possible to avoid this "mask push-down" in Arrow, but I don't know how
+                maskedjets = awkward.MaskedArray([False, False, True], jets, maskedwhen=True)
+                assert list(awkward.arrow.toarrow(maskedjets)) == [[{"fPt": 10.0, "fEta": -3.0, "fPhi": -1.5, "fMass": 60.0}, {"fPt": 20.0, "fEta": -2.0, "fPhi": 0.0, "fMass": 70.0}, {"fPt": 30.0, "fEta": 2.0, "fPhi": 1.5, "fMass": 80.0}], [], [{"fPt": None, "fEta": None, "fPhi": None, "fMass": None}, {"fPt": None, "fEta": None, "fPhi": None, "fMass": None}]]
 
     def test_arrow_array(self):
         if pyarrow is None:


### PR DESCRIPTION
Arrow → Awkward has existed for a while; Awkward → Arrow will probably be needed in the near future. (It keeps coming up; if it's as easy as I say it is, this PR will be quick.)