### PR TITLE
Clean up any issues of losing table keys after masking or indexing

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -753,19 +753,13 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
 
     def __setitem__(self, where, what):
         if isinstance(where, awkward.util.string):
-            if isinstance(what, JaggedArray):
-                self._content[where] = what._tojagged(self._starts, self._stops, copy=False)._content
-            else:
-                self._content[where] = self._broadcast(what)._content
+            self._content[where] = self._broadcast(what)._content
 
         elif self._util_isstringslice(where):
             if len(where) != len(what):
                 raise ValueError("number of keys ({0}) does not match number of provided arrays ({1})".format(len(where), len(what)))
             for x, y in zip(where, what):
-                if isinstance(y, JaggedArray):
-                    self._content[x] = y._tojagged(self._starts, self._stops, copy=False)._content
-                else:
-                    self._content[x] = self._broadcast(y)._content
+                self._content[x] = self._broadcast(y)._content
                 
         else:
             raise TypeError("invalid index for assigning column to Table: {0}".format(where))

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -792,7 +792,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             return self._broadcast(self.numpy.array(data))
 
         else:
-            return self._broadcast(self.numpy.array([data])[0])
+            return self._broadcast(self.numpy.array([data]))
 
     def _tojagged(self, starts=None, stops=None, copy=True):
         if starts is None and stops is None:

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -788,8 +788,11 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             out._parents = self.parents
             return out
 
+        elif isinstance(data, Iterable):
+            return self._broadcast(self.numpy.array(data))
+
         else:
-            return self._broadcast(self.numpy.array([data]))
+            return self._broadcast(self.numpy.array([data])[0])
 
     def _tojagged(self, starts=None, stops=None, copy=True):
         if starts is None and stops is None:

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -529,7 +529,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
                 headoffsets = self.counts2offsets(head.counts)
                 head = head._tojagged(headoffsets[:-1], headoffsets[1:], copy=False)
 
-                counts = head._broadcast(self.counts)._content
+                counts = head.tojagged(self.counts)._content
 
                 indexes = self.numpy.array(head._content[:headoffsets[-1]], copy=True)
 
@@ -539,7 +539,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
                 if not self.numpy.bitwise_and(0 <= indexes, indexes < counts).all():
                     raise IndexError("jagged array used as index contains out-of-bounds values")
 
-                indexes += head._broadcast(self._starts)._content
+                indexes += head.tojagged(self._starts)._content
 
                 return self.copy(starts=head._starts, stops=head._stops, content=self._content[indexes])
 
@@ -753,18 +753,18 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
 
     def __setitem__(self, where, what):
         if isinstance(where, awkward.util.string):
-            self._content[where] = self._broadcast(what)._content
+            self._content[where] = self.tojagged(what)._content
 
         elif self._util_isstringslice(where):
             if len(where) != len(what):
                 raise ValueError("number of keys ({0}) does not match number of provided arrays ({1})".format(len(where), len(what)))
             for x, y in zip(where, what):
-                self._content[x] = self._broadcast(y)._content
+                self._content[x] = self.tojagged(y)._content
                 
         else:
             raise TypeError("invalid index for assigning column to Table: {0}".format(where))
 
-    def _broadcast(self, data):
+    def tojagged(self, data):
         if isinstance(data, JaggedArray):
             if not self.numpy.array_equal(self.counts, data.counts):
                 raise ValueError("cannot broadcast JaggedArray to match JaggedArray with a different counts")
@@ -794,10 +794,10 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             return out
 
         elif isinstance(data, Iterable):
-            return self._broadcast(self.numpy.array(data))
+            return self.tojagged(self.numpy.array(data))
 
         else:
-            return self._broadcast(self.numpy.array([data]))
+            return self.tojagged(self.numpy.array([data]))
 
     def _tojagged(self, starts=None, stops=None, copy=True):
         if starts is None and stops is None:
@@ -1114,7 +1114,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         out["1"] = out["1"] - other._starts
 
         if nested:
-            out = self.JaggedArray.fromcounts(self.counts, self.JaggedArray.fromcounts(self._broadcast(other.counts).flatten(), out._content))
+            out = self.JaggedArray.fromcounts(self.counts, self.JaggedArray.fromcounts(self.tojagged(other.counts).flatten(), out._content))
 
         return out
 
@@ -1133,7 +1133,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
 
         if nested:
             old = out
-            out = self.JaggedArray.fromcounts(thyself.counts, self.JaggedArray.fromcounts(thyself._broadcast(other.counts).flatten(), out._content))
+            out = self.JaggedArray.fromcounts(thyself.counts, self.JaggedArray.fromcounts(thyself.tojagged(other.counts).flatten(), out._content))
             out._nestedcross = old
 
         if hasattr(self, "_nestedcross"):
@@ -1141,7 +1141,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             mask = (self.counts != 0)
             counts[mask] //= self.counts[mask]
             old = out
-            out = self.JaggedArray.fromcounts(self.counts, self.JaggedArray.fromcounts(self._broadcast(counts).flatten(), out._content))
+            out = self.JaggedArray.fromcounts(self.counts, self.JaggedArray.fromcounts(self.tojagged(counts).flatten(), out._content))
             out._nestedcross = old
 
         return out
@@ -1534,13 +1534,13 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
                 if isinstance(x, JaggedArray):
                     columns1[n] = x._content
                 elif isinstance(x, Iterable):
-                    columns1[n] = first._broadcast(x)._content
+                    columns1[n] = first.tojagged(x)._content
                 elif isinstance(x, (numbers.Number, numpy.number, numpy.bool, numpy.bool_)):
                     columns1[n] = JaggedArray(first._starts, first._stops, numpy.full(first._stops.max(), columns1, dtype=type(columns1)))._content
                 else:
                     raise TypeError("unrecognized type for JaggedArray.zip: {0}".format(type(x)))
         elif isinstance(columns1, Iterable):
-            columns1 = first._broadcast(columns1)._content
+            columns1 = first.tojagged(columns1)._content
         elif isinstance(columns1, (numbers.Number, numpy.number, numpy.bool, numpy.bool_)):
             columns1 = JaggedArray(first._starts, first._stops, numpy.full(first._stops.max(), columns1, dtype=type(columns1)))._content
         else:
@@ -1551,7 +1551,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             if isinstance(x, JaggedArray):
                 columns2[i] = x._content
             elif not isinstance(x, dict) and isinstance(x, Iterable):
-                columns2[i] = first._broadcast(x)._content
+                columns2[i] = first.tojagged(x)._content
             elif isinstance(x, (numbers.Number, numpy.number, numpy.bool, numpy.bool_)):
                 columns2[i] = JaggedArray(first._starts, first._stops, numpy.full(first._stops.max(), x, dtype=type(x)))._content
             else:
@@ -1562,7 +1562,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             if isinstance(x, JaggedArray):
                 columns3[n] = x._content
             elif not isinstance(x, dict) and isinstance(x, Iterable):
-                columns3[n] = first._broadcast(x)._content
+                columns3[n] = first.tojagged(x)._content
             elif isinstance(x, (numbers.Number, numpy.number, numpy.bool, numpy.bool_)):
                 columns3[n] = JaggedArray(first._starts, first._stops, numpy.full(first._stops.max(), x, dtype=type(x)))._content
             else:
@@ -1591,8 +1591,8 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             out = self._content.pandas()
 
         if isinstance(self._content, JaggedArray):
-            parents = self._content._broadcast(self.parents)._content
-            index = self._content._broadcast(self.index._content)._content
+            parents = self._content.tojagged(self.parents)._content
+            index = self._content.tojagged(self.index._content)._content
             out.index = pandas.MultiIndex.from_arrays([parents, index] + out.index.labels[1:])
         else:
             out.index = pandas.MultiIndex.from_arrays([self.parents, self.index._content])

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -581,12 +581,20 @@ class Table(awkward.array.base.AwkwardArray):
             raise ValueError("new columns can only be attached to the original Table, not a view (try table.base['col'] = array)")
 
         if isinstance(where, awkward.util.string):
+            try:
+                len(what)
+            except TypeError:
+                what = self.numpy.full(len(self), what)
             self._contents[where] = self._util_toarray(what, self.DEFAULTTYPE)
 
         elif self._util_isstringslice(where):
             if len(where) != len(what):
                 raise ValueError("number of keys ({0}) does not match number of provided arrays ({1})".format(len(where), len(what)))
             for x, y in zip(where, what):
+                try:
+                    len(y)
+                except TypeError:
+                    y = self.numpy.full(len(self), y)
                 self._contents[x] = self._util_toarray(y, self.DEFAULTTYPE)
 
         else:

--- a/awkward/arrow.py
+++ b/awkward/arrow.py
@@ -152,7 +152,7 @@ def toarrow(obj):
         elif isinstance(obj, awkward.array.jagged.JaggedArray):
             obj = obj.compact()
             if mask is not None:
-                mask = obj._broadcast(mask).flatten()
+                mask = obj.tojagged(mask).flatten()
             return pyarrow.ListArray.from_arrays(obj.offsets, recurse(obj.content, mask))
 
         elif isinstance(obj, awkward.array.masked.IndexedMaskedArray):

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Making sure that `JaggedArray._broadcast`, `Table.__setitem__` are robust against different types, etc.