### PR TITLE
Consistency in awkward.save, awkward.toparquet argument order

### DIFF
--- a/awkward/arrow.py
+++ b/awkward/arrow.py
@@ -398,7 +398,7 @@ def fromarrow(obj, awkwardlib=None):
 
 ################################################################################ Parquet file handling
 
-def toparquet(obj, where, **options):
+def toparquet(where, obj, **options):
     import pyarrow.parquet
 
     options["where"] = where

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -315,7 +315,11 @@ def serialize(obj, storage, name=None, delimiter="-", suffix=None, schemasuffix=
                 minsize, tpes, contexts, pair = policy["minsize"], policy["types"], policy["contexts"], policy["pair"]
                 if obj.nbytes >= minsize and issubclass(obj.dtype.type, tuple(tpes)) and any(fnmatch.fnmatchcase(context, p) for p in contexts):
                     compress, decompress = pair
-                    storage[prefix + str(ident) + suffix] = compress(obj)
+                    if obj.flags.c_contiguous:
+                        compressed = compress(obj)
+                    else:
+                        compressed = compress(obj.copy())
+                    storage[prefix + str(ident) + suffix] = compressed
 
                     return {"id": ident,
                             "call": ["awkward", "numpy", "frombuffer"],

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -347,9 +347,11 @@ def serialize(obj, storage, name=None, delimiter="-", suffix=None, schemasuffix=
 
                 gen, genname = importlib.import_module(spec[0]), spec[1:]
                 while len(genname) > 0:
+                    if not hasattr(gen, genname[0]):
+                        break
                     gen, genname = getattr(gen, genname[0]), genname[1:]
 
-                if gen is obj:
+                if len(genname) == 0 and gen is obj:
                     return {"id": ident, "function": spec}
 
             if hasattr(obj, "tojson") and hasattr(type(obj), "fromjson") and getattr(importlib.import_module(type(obj).__module__), type(obj).__name__) is type(obj):

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.8.12"
+__version__ = "0.8.13"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -424,17 +424,17 @@ def test_arrow_writeparquet2(tmpdir):
     a = awkward.fromiter([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
     b = awkward.fromiter([100, 200, None])
 
-    awkward.toparquet([b, b, b], filename)
+    awkward.toparquet(filename, [b, b, b])
     assert awkward.fromparquet(filename).tolist() == [100, 200, None, 100, 200, None, 100, 200, None]
 
-    awkward.toparquet(a, filename)
+    awkward.toparquet(filename, a)
     assert awkward.fromparquet(filename).tolist() == [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 
-    awkward.toparquet(awkward.Table(x=a, y=b), filename)
+    awkward.toparquet(filename, awkward.Table(x=a, y=b))
     c = awkward.fromparquet(filename)
     assert c.tolist() == [{'x': [1.1, 2.2, 3.3], 'y': 100}, {'x': [], 'y': 200}, {'x': [4.4, 5.5], 'y': None}]
 
-    awkward.toparquet(c, filename)
+    awkward.toparquet(filename, c)
     d = awkward.fromparquet(filename)
     assert c.tolist() == d.tolist()
     assert isinstance(c, awkward.ChunkedArray) and isinstance(d, awkward.ChunkedArray)


### PR DESCRIPTION
save and toparquet should have the same order of arguments: filename, then array to save (and awkward.save's order is set to be consistent with numpy.save)