### PR TITLE
Issue arrowbuffers toobig

### DIFF
--- a/awkward/array/masked.py
+++ b/awkward/array/masked.py
@@ -396,9 +396,6 @@ class BitMaskedArray(MaskedArray):
     def _valid(self):
         if self.check_whole_valid:
             if not self._isvalid:
-                if len(self._mask) != self._ceildiv8(len(self._content)):
-                    raise ValueError("mask length ({0}) must be equal to ceil(content length / 8) ({1})".format(len(self._mask), self._ceildiv8(len(self._content))))
-
                 self._isvalid = True
 
     def __iter__(self, checkiter=True):

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
If an Arrow ListArray (from RecordBatches at least) has at least 7 elements, its offset `buffers` will include a trailing `0`. We can detect this (other than non-monotonicity) because we have a "length" parameter from the RecordBatch that tells us where to cut off the excess data.

However, this means that the length must be propagated through my `popbuffers` function, since the correct length at one level of nested jaggedness can be completely unrelated to the next level: I have to discover the next length in from `offsets[-1]` (which is only correct if `offsets` has the right length). It can be computed recursively—but that had to be added.

Moreover, it means that I must deal with the current level of jaggedness before descending into the next one, because the only way to give it the next length is by applying this length. Thus, I had to change the whole pop-order from right-to-left (`buffers.pop()`) to left-to-right (`buffers.pop(0)`).