### PR TITLE
Add unzip functionality for tables and arrays

### DIFF
--- a/awkward/array/base.py
+++ b/awkward/array/base.py
@@ -447,39 +447,12 @@ class AwkwardArray(awkward.util.NDArrayOperatorsMixin):
         else:
             return array.fillna(value)
 
-    def should_use_column_dict(self):
-        if (hasattr(self, "rowname") and self.rowname != "tuple")\
-        or (hasattr(self, "content") and hasattr(self.content, "rowname") and self.content.rowname != "tuple")\
-        or (hasattr(self, "contents") and hasattr(self.contents, "rowname") and self.contents.rowname != "tuple"):
-            return True
-        else:
-            return False
-
-    def column_basic_iterator(self):
+    def column_iterator(self):
         for column_name in self.columns:
             yield self[column_name]
 
-    def column_dict_iterator(self):
-        for column_name in self.columns:
-            yield column_name, self[column_name]
-
-    def column_iterator(self):
-        if self.should_use_column_dict():
-            return self.column_dict_iterator()
-        else:
-            return self.column_basic_iterator()
-
-    def tuple_unzip(self):
-        return tuple(column for column in self.column_basic_iterator())
-
-    def dict_unzip(self):
-        return {column_name: column for column_name, column in self.column_dict_iterator()}
-
     def unzip(self):
-        if self.should_use_column_dict():
-            return self.dict_unzip()
-        else:
-            return self.tuple_unzip()
+        return tuple(column for column in self.column_iterator())
 
 class AwkwardArrayWithContent(AwkwardArray):
     """

--- a/awkward/array/base.py
+++ b/awkward/array/base.py
@@ -447,12 +447,8 @@ class AwkwardArray(awkward.util.NDArrayOperatorsMixin):
         else:
             return array.fillna(value)
 
-    def column_iterator(self):
-        for column_name in self.columns:
-            yield self[column_name]
-
     def unzip(self):
-        return tuple(column for column in self.column_iterator())
+        return tuple(self[column_name] for column_name in self.columns)
 
 class AwkwardArrayWithContent(AwkwardArray):
     """

--- a/awkward/array/base.py
+++ b/awkward/array/base.py
@@ -447,6 +447,40 @@ class AwkwardArray(awkward.util.NDArrayOperatorsMixin):
         else:
             return array.fillna(value)
 
+    def should_use_column_dict(self):
+        if (hasattr(self, "rowname") and self.rowname != "tuple")\
+        or (hasattr(self, "content") and hasattr(self.content, "rowname") and self.content.rowname != "tuple")\
+        or (hasattr(self, "contents") and hasattr(self.contents, "rowname") and self.contents.rowname != "tuple"):
+            return True
+        else:
+            return False
+
+    def column_basic_iterator(self):
+        for column_name in self.columns:
+            yield self[column_name]
+
+    def column_dict_iterator(self):
+        for column_name in self.columns:
+            yield column_name, self[column_name]
+
+    def column_iterator(self):
+        if self.should_use_column_dict():
+            return self.column_dict_iterator()
+        else:
+            return self.column_basic_iterator()
+
+    def tuple_unzip(self):
+        return tuple(column for column in self.column_basic_iterator())
+
+    def dict_unzip(self):
+        return {column_name: column for column_name, column in self.column_dict_iterator()}
+
+    def unzip(self):
+        if self.should_use_column_dict():
+            return self.dict_unzip()
+        else:
+            return self.tuple_unzip()
+
 class AwkwardArrayWithContent(AwkwardArray):
     """
     AwkwardArrayWithContent: abstract base class

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -550,3 +550,41 @@ class Test(unittest.TestCase):
         a = awkward.fromiter([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
         assert a.pad(4).fillna(999).tolist() == [[1.1, 2.2, 3.3, 999], [999, 999, 999, 999], [4.4, 5.5, 999, 999]]
         assert a.pad(4, numpy.ma.masked).fillna(999).regular().tolist() == [[1.1, 2.2, 3.3, 999], [999, 999, 999, 999], [4.4, 5.5, 999, 999]]
+
+    def test_jagged_unzip(self):
+        a = fromiter([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
+        b = JaggedArray([1, 5, 5], [4, 5, 7], [999, 10, 20, 30, 999, 40, 50, 999])
+        c = numpy.array([100, 200, 300])
+        d = 1000
+
+        def check_2_dict_contents(two_dict, one, two):
+            assert type(two_dict) is dict
+            assert len(two_dict) == 2
+            assert all((two_dict["one"] == one).flatten())
+            assert all((two_dict["two"] == two).flatten())
+
+        unzip_ab_1 = JaggedArray.zip(one=a, two=b).unzip()
+        unzip_ba_1 = JaggedArray.zip(one=b, two=a).unzip()
+        unzip_bc_1 = JaggedArray.zip(one=b, two=c).unzip()
+        unzip_bd_1 = JaggedArray.zip(one=b, two=d).unzip()
+
+        check_2_dict_contents(unzip_ab_1, a, b)
+        check_2_dict_contents(unzip_ba_1, b, a)
+        check_2_dict_contents(unzip_bc_1, b, c)
+        check_2_dict_contents(unzip_bd_1, b, d)
+
+        def check_2_tuple_contents(two_tuple, one, two):
+            assert type(two_tuple) is tuple
+            assert len(two_tuple) == 2
+            assert all((two_tuple[0] == one).flatten())
+            assert all((two_tuple[1] == two).flatten())
+
+        unzip_ab_2 = a.zip(b).unzip()
+        unzip_ba_2 = b.zip(a).unzip()
+        unzip_bc_2 = b.zip(c).unzip()
+        unzip_bd_2 = b.zip(d).unzip()
+
+        check_2_tuple_contents(unzip_ab_2, a, b)
+        check_2_tuple_contents(unzip_ba_2, b, a)
+        check_2_tuple_contents(unzip_bc_2, b, c)
+        check_2_tuple_contents(unzip_bd_2, b, d)

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -557,34 +557,18 @@ class Test(unittest.TestCase):
         c = numpy.array([100, 200, 300])
         d = 1000
 
-        def check_2_dict_contents(two_dict, one, two):
-            assert type(two_dict) is dict
-            assert len(two_dict) == 2
-            assert all((two_dict["one"] == one).flatten())
-            assert all((two_dict["two"] == two).flatten())
-
-        unzip_ab_1 = JaggedArray.zip(one=a, two=b).unzip()
-        unzip_ba_1 = JaggedArray.zip(one=b, two=a).unzip()
-        unzip_bc_1 = JaggedArray.zip(one=b, two=c).unzip()
-        unzip_bd_1 = JaggedArray.zip(one=b, two=d).unzip()
-
-        check_2_dict_contents(unzip_ab_1, a, b)
-        check_2_dict_contents(unzip_ba_1, b, a)
-        check_2_dict_contents(unzip_bc_1, b, c)
-        check_2_dict_contents(unzip_bd_1, b, d)
-
         def check_2_tuple_contents(two_tuple, one, two):
             assert type(two_tuple) is tuple
             assert len(two_tuple) == 2
             assert all((two_tuple[0] == one).flatten())
             assert all((two_tuple[1] == two).flatten())
 
-        unzip_ab_2 = a.zip(b).unzip()
-        unzip_ba_2 = b.zip(a).unzip()
-        unzip_bc_2 = b.zip(c).unzip()
-        unzip_bd_2 = b.zip(d).unzip()
+        unzip_ab = a.zip(b).unzip()
+        unzip_ba = b.zip(a).unzip()
+        unzip_bc = b.zip(c).unzip()
+        unzip_bd = b.zip(d).unzip()
 
-        check_2_tuple_contents(unzip_ab_2, a, b)
-        check_2_tuple_contents(unzip_ba_2, b, a)
-        check_2_tuple_contents(unzip_bc_2, b, c)
-        check_2_tuple_contents(unzip_bd_2, b, d)
+        check_2_tuple_contents(unzip_ab, a, b)
+        check_2_tuple_contents(unzip_ba, b, a)
+        check_2_tuple_contents(unzip_bc, b, c)
+        check_2_tuple_contents(unzip_bd, b, d)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -152,7 +152,7 @@ class Test(unittest.TestCase):
         assert c.tolist() == [{"0": 0, "1": 0.0}, {"0": 1, "1": 1.1}, {"0": 2, "1": 2.2},
                               {"0": 4, "1": 4.4}, {"0": 5, "1": 5.5}, ]
 
-    def test_table_tuple_unzip(self):
+    def test_table_unzip(self):
         left = [1, 2, 3, 4, 5]
         right = [6, 7, 8, 9, 10]
         table = Table.named("tuple", left, right)
@@ -161,12 +161,3 @@ class Test(unittest.TestCase):
         assert len(unzip) == 2
         assert all(unzip[0] == left)
         assert all(unzip[1] == right)
-
-    def test_table_dict_unzip(self):
-        columns = [[1, 2], [3, 4], [5, 6], [7, 8]]
-        table = Table(*columns)
-        unzip = table.unzip()
-        assert type(unzip) is dict
-        assert len(unzip) == len(columns)
-        for column_i in range(len(columns)):
-            assert unzip[str(column_i)].tolist() == columns[column_i]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -151,3 +151,22 @@ class Test(unittest.TestCase):
 
         assert c.tolist() == [{"0": 0, "1": 0.0}, {"0": 1, "1": 1.1}, {"0": 2, "1": 2.2},
                               {"0": 4, "1": 4.4}, {"0": 5, "1": 5.5}, ]
+
+    def test_table_tuple_unzip(self):
+        left = [1, 2, 3, 4, 5]
+        right = [6, 7, 8, 9, 10]
+        table = Table.named("tuple", left, right)
+        unzip = table.unzip()
+        assert type(unzip) is tuple
+        assert len(unzip) == 2
+        assert all(unzip[0] == left)
+        assert all(unzip[1] == right)
+
+    def test_table_dict_unzip(self):
+        columns = [[1, 2], [3, 4], [5, 6], [7, 8]]
+        table = Table(*columns)
+        unzip = table.unzip()
+        assert type(unzip) is dict
+        assert len(unzip) == len(columns)
+        for column_i in range(len(columns)):
+            assert unzip[str(column_i)].tolist() == columns[column_i]


### PR DESCRIPTION
I've added a few methods that help make `zip()` a reversible process. This addresses #115, although the main reason I've been interested in this is to get a tuple of arrays out of `JaggedArray.argcross()` as opposed to an array of tuples, as referenced in the issue.