### PR TITLE
Fix JaggedArray._reduce() when content goes past last offset

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -1432,7 +1432,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             out = self.numpy.empty(thyself._starts.shape[:1] + content.shape[1:], dtype=dtype)
 
         if len(out) != 0:
-            nonterminal = thyself.offsets[thyself.offsets != thyself.offsets[-1]]
+            nonterminal = thyself.offsets[thyself.offsets < len(content)]
             if os.name == "nt":    # Windows Numpy reduceat requires 32-bit indexes
                 nonterminal = nonterminal.astype(self.numpy.int32)
 
@@ -1440,7 +1440,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
                 for axis in range(1, len(content.shape)):
                     content = ufunc.reduce(content, axis=axis)
 
-            out[:len(nonterminal)] = ufunc.reduceat(content, nonterminal)
+            out = ufunc.reduceat(content, nonterminal)[:len(out)]
             out[thyself.starts == thyself.stops] = identity
 
         if regularaxis is None:

--- a/tests/test_crosscut.py
+++ b/tests/test_crosscut.py
@@ -108,7 +108,7 @@ class Test(unittest.TestCase):
         a = IndexedArray([3, 2, 4, 2, 2, 4, 0], [0.0, 1.1, 2.2, 3.3, 4.4])
         assert a.sum() == 18.700000000000003
         a = JaggedArray.fromcounts([3, 0, 2], IndexedArray([3, 2, 4, 2, 2, 4, 0], [0.0, 1.1, 2.2, 3.3, 4.4]))
-        assert a.sum().tolist() == [9.9, 0.0, 8.8]
+        assert a.sum().tolist() == [9.9, 0.0, 4.4]
         a = IndexedArray([3, 2, 4, 2, 2, 4, 0], JaggedArray.fromcounts([3, 0, 2, 1, 4], [0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]))
         assert a.sum().tolist() == [5.5, 7.7, 33.0, 7.7, 7.7, 33.0, 3.3000000000000003]
         a = IndexedArray([3, 2, 4, 2, 2, 4, 0], Table.named("tuple", [0.0, 1.1, 2.2, 3.3, 4.4], [0, 100, 200, 300, 400]))


### PR DESCRIPTION
I noticed this from a large array loaded through uproot. If `content` goes past the last offset in a JaggedArray, the last range run over by `ufunc.reduceat()` will be from that offset to the end of `content`, regardless of whether those elements are actually in the array.

Example:
```python
import awkward
a = awkward.JaggedArray.fromcounts([1, 2, 3], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
print('a =', a)
print('a.count() =', a.count())
```
Output:
```python
a = [[1] [2 3] [4 5 6]]
a.count() = [1 2 7]
```

The elements past 6 are being counted as part of the last row. The change that I made was to take all offsets less then `len(content)`, so that if this value is not equal to the last offset, the last row will still be counted correctly.

Incidentally, there is apparently a test that already would have been failing on this, but the comparison value is set to the wrong output. I've fixed this, so it shouldn't be giving false positives anymore.