### PR TITLE
Boolean indexing fix

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -538,7 +538,14 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
                 offsets = self.counts2offsets(intheadsum)
 
                 headcontent = self.numpy.array(head._content, dtype=self.BOOLTYPE)
-                headcontent[head.parents < 0] = False
+
+                headcontent_indices_to_ignore = self.numpy.resize(head.parents < 0, headcontent.shape)
+                headcontent_indices_to_ignore[len(head.parents):] = True
+                headcontent[headcontent_indices_to_ignore] = False
+
+                original_headcontent_length = len(headcontent)
+                headcontent.resize(thyself._content.shape)
+                headcontent[original_headcontent_length:] = False
 
                 return self.copy(starts=offsets[:-1].reshape(intheadsum.shape), stops=offsets[1:].reshape(intheadsum.shape), content=thyself._content[headcontent])
 

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -544,7 +544,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
                 headcontent[headcontent_indices_to_ignore] = False
 
                 original_headcontent_length = len(headcontent)
-                headcontent.resize(thyself._content.shape)
+                headcontent = self.numpy.resize(headcontent, thyself._content.shape)
                 headcontent[original_headcontent_length:] = False
 
                 return self.copy(starts=offsets[:-1].reshape(intheadsum.shape), stops=offsets[1:].reshape(intheadsum.shape), content=thyself._content[headcontent])

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -572,3 +572,12 @@ class Test(unittest.TestCase):
         check_2_tuple_contents(unzip_ba, b, a)
         check_2_tuple_contents(unzip_bc, b, c)
         check_2_tuple_contents(unzip_bd, b, d)
+
+    def test_jagged_boolean_indexing(self):
+        array1 = JaggedArray.fromcounts([1], [0])
+        array2 = JaggedArray.fromcounts([1], [0, 1])
+        indices1 = JaggedArray.fromcounts([1], [True])
+        indices2 = JaggedArray.fromcounts([1], [True, False])
+        assert all(array1[indices1] == array1[indices2])
+        assert all(array1[indices1] == array2[indices1])
+        assert all(array2[indices1] == array2[indices2])


### PR DESCRIPTION
This fixes another issue that I noticed with JaggedArrays that have content beyond the visible elements in the array. Take the following cases of trying to use boolean indexing/masking:
```python
>>> from awkward import JaggedArray
>>> array = JaggedArray.fromcounts([1], [0, 1])
>>> array
<JaggedArray [[0]] at 0x7f86725d72b0>
>>> indices = JaggedArray.fromcounts([1], [True])
>>> indices
<JaggedArray [[True]] at 0x7f867082c828>
>>> array[indices]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/cern/iris/awkward-array/awkward/array/jagged.py", line 543, in __getitem__
    return self.copy(starts=offsets[:-1].reshape(intheadsum.shape), stops=offsets[1:].reshape(intheadsum.shape), content=thyself._content[headcontent])
IndexError: boolean index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 1
>>> array = JaggedArray.fromcounts([1], [0])
>>> array
<JaggedArray [[0]] at 0x7f86725d7358>
>>> indices = JaggedArray.fromcounts([1], [True, False])
>>> indices
<JaggedArray [[True]] at 0x7f86725d7278>
>>> array[indices]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/cern/iris/awkward-array/awkward/array/jagged.py", line 541, in __getitem__
    headcontent[head.parents < 0] = False
IndexError: boolean index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 1
```
If the content shapes don't match between the array being indexed and the boolean array used for indexing, there's an error. But the visible shapes of the two arrays do match, so it should work. I added a basic test that fails on this. The fix involves a couple resizes to make sure shapes match when numpy arrays are indexed in `JaggedArray.__getitem__()`.