### PR TITLE
Proposal: class-ify persists.serialize

### DIFF
--- a/awkward/array/indexed.py
+++ b/awkward/array/indexed.py
@@ -68,12 +68,13 @@ class IndexedArray(awkward.array.base.AwkwardArrayWithContent):
         else:
             return self.copy(content=self._content.ones_like(**overrides))
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
-        return {"id": ident,
-                "call": ["awkward", "IndexedArray"],
-                "args": [fill(self._index, "IndexedArray.index", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(self._content, "IndexedArray.content", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+        return serializer.encode_call(
+            ["awkward", "IndexedArray"],
+            serializer(self._index, "IndexedArray.index"),
+            serializer(self._content, "IndexedArray.content"),
+        )
 
     @property
     def index(self):
@@ -294,24 +295,15 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
         else:
             return self.copy(content=self._content.ones_like(**overrides), **mine)
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
-        
-        if self._default is None:
-            default = {"json": self._default}
-        elif self._util_isinteger(self._default):
-            default = {"json": int(self._default)}
-        elif isinstance(self._default, (numbers.Real, self.numpy.floating)) and self.numpy.isfinite(self._default):
-            default = {"json": float(self._default)}
-        else:
-            default = fill(self._default, "SparseArray.default", prefix, suffix, schemasuffix, storage, compression, **kwargs)
-
-        return {"id": ident,
-                "call": ["awkward", "SparseArray"],
-                "args": [{"json": int(self._length)},
-                         fill(self._index, "SparseArray.index", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         fill(self._content, "SparseArray.content", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                         default]}
+        return serializer.encode_call(
+            ["awkward", "SparseArray"],
+            {"json": int(self._length)},
+            serializer(self._index, "SparseArray.index"),
+            serializer(self._content, "SparseArray.content"),
+            serializer(self._default, "SparseArray.default"),
+        )
 
     @property
     def length(self):
@@ -323,7 +315,7 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
             if not self._util_isinteger(value):
                 raise TypeError("length must be an integer")
             if value < 0:
-                raise ValueError("length must be a non-negative integer") 
+                raise ValueError("length must be a non-negative integer")
         self._length = value
 
     @property
@@ -473,7 +465,7 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
                 length = d + (1 if m != 0 else 0)
             else:
                 length = 0
-            
+
             if abs(step) > 1:
                 index, remainder = self.numpy.divmod(index, abs(step))
                 mask[remainder != 0] = False
@@ -523,7 +515,7 @@ class SparseArray(awkward.array.base.AwkwardArrayWithContent):
                     head[mask] += self._length
                 if (head < 0).any() or (head >= self._length).any():
                     raise IndexError("indexes out of bounds for size {0}".format(self._length))
-                
+
                 match = self.numpy.searchsorted(self._index, head, side="left")
                 match[match >= len(self._index)] = len(self._index) - 1
                 explicit = (self._index[match] == head)

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -266,19 +266,20 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         else:
             return self.copy(content=self._content.ones_like(**overrides))
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
-        self._valid()
-        if self.offsetsaliased(self._starts, self._stops) and len(self._starts) > 0 and self._starts[0] == 0:
-            return {"id": ident,
-                    "call": ["awkward", "JaggedArray", "fromcounts"],
-                    "args": [fill(self.counts, "JaggedArray.counts", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                             fill(self._content, "JaggedArray.content", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+    def __awkward_serialize__(self, serializer):
+        if self._canuseoffset():
+            return serializer.encode_call(
+                ["awkward", "JaggedArray", "fromcounts"],
+                serializer(self.counts, "JaggedArray.counts"),
+                serializer(self._content, "JaggedArray.content"),
+            )
         else:
-            return {"id": ident,
-                    "call": ["awkward", "JaggedArray"],
-                    "args": [fill(self._starts, "JaggedArray.starts", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                             fill(self._stops, "JaggedArray.stops", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                             fill(self._content, "JaggedArray.content", prefix, suffix, schemasuffix, storage, compression, **kwargs)]}
+            return serializer.encode_call(
+                ["awkward", "JaggedArray"],
+                serializer(self._starts, "JaggedArray.starts"),
+                serializer(self._stops, "JaggedArray.stops"),
+                serializer(self._content, "JaggedArray.content"),
+            )
 
     @property
     def starts(self):

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -285,7 +285,7 @@ class Table(awkward.array.base.AwkwardArray):
             out._base = base
             out._rowstart = None
             return out
-            
+
         else:
             raise TypeError("view must be None, a 3-tuple of integers, or a Numpy array of integers")
 
@@ -339,21 +339,35 @@ class Table(awkward.array.base.AwkwardArray):
                 out[n] = x.ones_like(**overrides)
         return out
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
-        out = {"call": ["awkward", "Table", "frompairs"],
-               "args": [{"pairs": [[n, fill(x, "Table.contents", prefix, suffix, schemasuffix, storage, compression, **kwargs)] for n, x in self._contents.items()]},
-                        {"json": self.rowstart}]}
+        out = serializer.encode_call(
+            ["awkward", "Table", "frompairs"],
+            {"pairs": [
+                [n, serializer(x, "Table.contents")]
+                for n, x in self._contents.items()
+            ]},
+            {"json": self.rowstart}
+        )
         if isinstance(self._view, tuple):
             start, step, length = self._view
-            out = {"call": ["awkward", "Table", "fromview"],
-                   "args": [{"tuple": [{"json": start}, {"json": step}, {"json": length}]}, out]}
+            out = serializer.encode_call(
+                ["awkward", "Table", "fromview"],
+                {"tuple": [
+                    {"json": start},
+                    {"json": step},
+                    {"json": length},
+                ]},
+                out,
+            )
 
         elif isinstance(self._view, self.numpy.ndarray):
-            out = {"call": ["awkward", "Table", "fromview"],
-                   "args": [fill(self._view, "Table" + ".view", prefix, suffix, schemasuffix, storage, compression, **kwargs), out]}
+            out = serializer.encode_call(
+                ["awkward", "Table", "fromview"],
+                serializer(self._view, "Table.view"),
+                out
+            )
 
-        out["id"] = ident
         return out
 
     @property

--- a/awkward/array/virtual.py
+++ b/awkward/array/virtual.py
@@ -108,31 +108,40 @@ class VirtualArray(awkward.array.base.AwkwardArray):
         else:
             return self.array.ones_like(**overrides)
 
-    def __awkward_persist__(self, ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+    def __awkward_serialize__(self, serializer):
         self._valid()
-        
+
         if self._persistvirtual:
-            out = {"id": ident,
-                   "call": ["awkward", "VirtualArray"],
-                   "args": [fill(self._generator, "VirtualArray.generator", prefix, suffix, schemasuffix, storage, compression, **kwargs),
-                            {"tuple": [fill(x, "VirtualArray.args", prefix, suffix, schemasuffix, storage, compression, **kwargs) for x in self._args]},
-                            {"dict": {n: fill(x, "VirtualArray.kwargs", prefix, suffix, schemasuffix, storage, compression, **kwargs) for n, x in self._kwargs.items()}}],
-                   "cacheable": True}
+            out = serializer.encode_call(
+                ["awkward", "VirtualArray"],
+                serializer(self._generator, "VirtualArray.generator"),
+                {"tuple": [
+                    serializer(x, "VirtualArray.args")
+                    for x in self._args
+                ]},
+                {"dict": {
+                    n: serializer(x, "VirtualArray.kwargs")
+                    for n, x in self._kwargs.items()
+                }}
+            )
+            out["cacheable"] = True
             others = {}
             if self._persistentkey is not None:
-                try:
-                    others["persistentkey"] = {"json": awkward.persist.jsonable(self._persistentkey)}
-                except TypeError:
-                    others["persistentkey"] = {"python": awkward.persist.frompython(self._persistentkey)}
+                others["persistentkey"] = serializer(self._persistentkey)
 
             if self._type is not None:
-                others["type"] = {"call": ["awkward.persist", "json2type"], "args": [{"json": awkward.persist.type2json(self._type)}], "whitelistable": True}
-            if len(others) > 0:
+                others["type"] = serializer.encode_call(
+                    ["awkward.persist", "json2type"],
+                    {"json": awkward.persist.type2json(self._type)},
+                )
+                others["type"]["whitelistable"] = True
+            if others:
                 out["kwargs"] = others
-            return out
-
         else:
-            return fill(self.array, "VirtualArray.array", prefix, suffix, schemasuffix, storage, compression, **kwargs)
+            out = serializer(self.array, "VirtualArray.array")
+            out.pop("id")
+
+        return out
 
     @property
     def generator(self):
@@ -242,7 +251,7 @@ class VirtualArray(awkward.array.base.AwkwardArray):
                 if not self._util_isinteger(value):
                     raise TypeError("nbytes must be an integer or None")
                 if value < 0:
-                    raise ValueError("nbytes must be a non-negative integer or None") 
+                    raise ValueError("nbytes must be a non-negative integer or None")
             self._nbytes = value
 
     def __len__(self):

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -444,16 +444,20 @@ class BlobSerializer(Serializer):
                 enc, dec = pair
             if dec is None:
                 dec = self.enc2dec[enc]
-            if not isinstance(types, (tuple, list)):
-                types = (types,)
-            if not isinstance(contexts, (tuple, list)):
-                contexts = (contexts,)
+            if isinstance(types, list):
+                types = tuple(types)
+            elif not isinstance(types, tuple):
+                types = types,
+            if isinstance(contexts, list):
+                contexts = tuple(contexts)
+            elif not isinstance(contexts, tuple):
+                contexts = contexts,
             assert callable(enc)
             assert isinstance(dec, tuple)
             assert 0 <= minsize
             self.enc = enc
             self.dec = dec
-            self.minsize = 0
+            self.minsize = minsize
             self.types = types
             self.contexts = contexts
 
@@ -478,8 +482,9 @@ class BlobSerializer(Serializer):
         return list(map(cls.CompressPolicy.parse, comp))
 
     def __init__(self, *args, **kwargs):
-        self.compression = kwargs.pop("compression", compression)
-        self._parse_compression(self.compression)
+        self.compression = self._parse_compression(
+            kwargs.pop("compression", compression)
+        )
         super(BlobSerializer, self).__init__(*args, **kwargs)
 
     def _put_raw(self, data, ref=None):

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -12,6 +12,7 @@ import pickle
 import types
 import zipfile
 import zlib
+from itertools import count
 try:
     from collections.abc import Mapping, MutableMapping
 except ImportError:
@@ -21,14 +22,6 @@ import numpy
 
 import awkward.type
 import awkward.version
-
-compression = [
-        {"minsize": 8192, "types": [numpy.bool_, numpy.bool, numpy.integer], "contexts": "*", "pair": (zlib.compress, ("zlib", "decompress"))},
-    ]
-
-partner = {
-        zlib.compress: ("zlib", "decompress"),
-    }
 
 whitelist = [
         ["numpy", "frombuffer"],
@@ -233,144 +226,301 @@ def jsonable(obj):
     else:
         raise TypeError("object cannot be losslessly serialized as JSON")
 
-def serialize(obj, storage, name=None, delimiter="-", suffix=None, schemasuffix=None, compression=compression, **kwargs):
-    import awkward.array.base
-    import awkward.array.virtual
+class ObjRef(object):
+    def __init__(self, idgen=None):
+        if idgen:
+            self.idgen = iter(idgen)
+        self._i2r = {}
+        self._r2o = {}
 
-    for n in kwargs:
-        if n not in ():
-            raise TypeError("unrecognized serialization option: {0}".format(repr(n)))
+    def nextid(self):
+        return next(self.idgen)
 
-    if name is None or name == "":
-        name = ""
-        prefix = ""
-    elif delimiter is None:
-        prefix = name
-    else:
-        prefix = name + delimiter
+    def __contains__(self, obj):
+        return id(obj) in self._i2r
 
-    if suffix is None:
-        suffix = ""
+    def __setitem__(self, obj, ref):
+        self._i2r[id(obj)] = ref
+        self._r2o[ref] = obj
 
-    if schemasuffix is None:
-        schemasuffix = ""
+    def __getitem__(self, obj):
+        if obj not in self:
+            self[obj] = self.nextid()
+        return self._i2r[id(obj)]
 
-    if compression is None:
-        compression = []
-    if isinstance(compression, dict) or callable(compression) or (len(compression) == 2 and callable(compression[0])):
-        compression = [compression]
+    def __delitem__(self, obj):
+        assert obj in self
+        del self._r2o[self._i2r[id(obj)]]
+        del self._i2r[id(obj)]
 
-    normalized = []
-    for x in compression:
-        if isinstance(x, dict):
-            pass
+    def get(self, obj, default=None):
+        return self[obj] if obj in self else default
 
-        elif callable(x):
-            if not x in partner:
-                raise ValueError("decompression partner for {0} not known".format(x))
-            x = {"pair": (x, partner[x])}
+    def obj(self, ref):
+        if ref in self._r2o:
+            return self._r2o[ref]
+        else:
+            return awkward.array.virtual.VirtualArray(lambda: self._r2o[ref])
 
-        elif len(x) == 2 and callable(x[0]):
-            x = {"pair": x}
+class Serializer(object):
+    def __init__(self, storage, prefix="", suffix="", schemasuffix=""):
+        self.storage = storage
+        self.suffix = suffix
+        self.prefix = prefix
+        self.schemasuffix = schemasuffix
+        self.seen = ObjRef(idgen=count())
 
-        minsize = x.get("minsize", 0)
-        tpes = x.get("types", (object,))
-        if not isinstance(tpes, tuple):
-            try:
-                tpes = tuple(tpes)
-            except TypeError:
-                tpes = (tpes,)
-        contexts = x.get("contexts", "*")
-        pair = x["pair"]
+    def store(self, name, obj):
+        schema = dict(
+            awkward=awkward.version.__version__,
+            schema=self(obj),
+        )
+        if self.prefix != "":
+            schema["prefix"] = self.prefix
 
-        normalized.append({"minsize": minsize, "types": tpes, "contexts": contexts, "pair": pair})
+        schema = self._finalize_schema(schema) or schema
 
-    seen = {}
-    def fill(obj, context, prefix, suffix, schemasuffix, storage, compression, **kwargs):
-        if id(obj) in seen:
-            return {"ref": seen[id(obj)]}
+        self.storage[name + self.schemasuffix] = self._encode_schema(schema)
+        return schema
 
-        ident = len(seen)
-        seen[id(obj)] = ident
+    def load(self, *args, **kwargs):
+        return deserialize(*args, storage=self.storage, seen=self.seen, **kwargs)
 
-        if type(obj) is numpy.dtype:
+    # encoding helper
+    def encode_call(self, *args, **kwargs):
+        func, args = args[0], args[1:]
+        ret = dict(
+            call=self._obj2spec(func) if callable(func) else tuple(func),
+        )
+        if args:
+            ret["args"] = list(args)
+        if kwargs:
+            ret["kwargs"] = kwargs
+        return ret
+
+    def encode_json(self, obj):
+        return dict(json=jsonable(obj))
+
+    def encode_python(self, obj):
+        return dict(python=frompython(obj))
+
+    # internal encoding hooks
+    @classmethod
+    def _encode_primitive(cls, obj):
+        if isinstance(obj, numpy.dtype):
             return {"dtype": dtype2json(obj)}
 
-        elif type(obj) is numpy.ndarray and len(obj.shape) != 0:
-            if len(obj.shape) > 1:
-                dtype = numpy.dtype((obj.dtype, obj.shape[1:]))
-            else:
-                dtype = obj.dtype
-
-            for policy in normalized:
-                minsize, tpes, contexts, pair = policy["minsize"], policy["types"], policy["contexts"], policy["pair"]
-                if obj.nbytes >= minsize and issubclass(obj.dtype.type, tuple(tpes)) and any(fnmatch.fnmatchcase(context, p) for p in contexts):
-                    compress, decompress = pair
-                    if obj.flags.c_contiguous:
-                        compressed = compress(obj)
-                    else:
-                        compressed = compress(obj.copy())
-                    storage[prefix + str(ident) + suffix] = compressed
-
-                    return {"id": ident,
-                            "call": ["awkward", "numpy", "frombuffer"],
-                            "args": [{"call": decompress, "args": [{"read": str(ident) + suffix}]},
-                                     {"dtype": dtype2json(dtype)},
-                                     {"json": len(obj)}]}
-
-            else:
-                storage[prefix + str(ident) + suffix] = obj.tostring()
-                return {"id": ident,
-                        "call": ["awkward", "numpy", "frombuffer"],
-                        "args": [{"read": str(ident) + suffix},
-                                 {"dtype": dtype2json(dtype)},
-                                 {"json": len(obj)}]}
-
-        elif hasattr(obj, "__awkward_persist__"):
-            return obj.__awkward_persist__(ident, fill, prefix, suffix, schemasuffix, storage, compression, **kwargs)
-
+    @classmethod
+    def _obj2spec(cls, obj, test=True):
+        if hasattr(obj, "__qualname__"):
+            spec = [obj.__module__] + obj.__qualname__.split(".")
         else:
-            if hasattr(obj, "__module__") and (hasattr(obj, "__qualname__") or hasattr(obj, "__name__")) and obj.__module__ != "__main__":
-                if hasattr(obj, "__qualname__"):
-                    spec = [obj.__module__] + obj.__qualname__.split(".")
-                else:
-                    spec = [obj.__module__, obj.__name__]
+            spec = [obj.__module__, obj.__name__]
 
-                gen, genname = importlib.import_module(spec[0]), spec[1:]
-                while len(genname) > 0:
-                    if not hasattr(gen, genname[0]):
-                        break
-                    gen, genname = getattr(gen, genname[0]), genname[1:]
+        if test:
+            val = importlib.import_module(spec[0])
+            for key in spec[1:]:
+                val = getattr(val, key)
+            assert val == obj
 
-                if len(genname) == 0 and gen is obj:
-                    return {"id": ident, "function": spec}
+        return spec
 
-            if hasattr(obj, "tojson") and hasattr(type(obj), "fromjson") and getattr(importlib.import_module(type(obj).__module__), type(obj).__name__) is type(obj):
-                try:
-                    return {"id": ident, "call": [type(obj).__module__, type(obj).__name__, "fromjson"], "args": [{"json": obj.tojson()}]}
-                except:
-                    pass
+    def _encode_complex(self, obj, context):
+        # TODO: get rid of this signature
+        if callable(getattr(obj, "__awkward_serialize__", None)):
+            return obj.__awkward_serialize__(self)
+        if callable(getattr(obj, "__awkward_persist__", None)):
+            return obj.__awkward_persist__(
+                ident=self.seen.get(obj, None),
+                fill=self.fill,
+                prefix=self.prefix,
+                suffix=self.suffix,
+                schemasuffix=self.schemasuffix,
+                storage=self.storage,
+                compression=self.compression,
+            )
 
+        if hasattr(obj, "tojson") and hasattr(type(obj), "fromjson"):
             try:
-                obj = jsonable(obj)
-            except TypeError:
-                try:
-                    return {"id": ident, "python": awkward.persist.frompython(obj)}
+                return self.encode_call(
+                    self._obj2spec(type(obj).fromjson),
+                    self.encode_json(obj.tojson()),
+                )
+            except:
+                pass
 
-                except Exception as err:
-                    raise TypeError("could not persist component as an array, awkward-array, importable function/class, JSON, or pickle; pickle error is\n\n    {0}: {1}".format(err.__class__.__name__, str(err)))
+        if isinstance(obj, numpy.ndarray):
+            return self._encode_numpy(obj, context)
+
+        if hasattr(obj, "__module__") and (
+            hasattr(obj, "__qualname__") or hasattr(obj, "__name__")
+        ) and obj.__module__ != "__main__":
+            try:
+                return dict(function=self._obj2spec(obj))
+            except:
+                pass
+
+        try:
+            return self.encode_json(obj)
+        except TypeError:
+            pass
+
+        try:
+            return self.encode_python(obj)
+        except:
+            pass
+
+    def _encode_numpy(self, obj, context):
+        key = str(self.seen[obj]) + self.suffix
+        self.storage[self.prefix + key] = obj
+        return dict(read=key)
+
+    def _encode_schema(self, schema):
+        return json.dumps(schema).encode("ascii")
+
+    def _finalize_schema(self, schema):
+        pass
+
+    def __call__(self, obj, context=""):
+        ret = self._encode_primitive(obj)
+
+        if ret is not None:
+            return ret
+
+        if obj in self.seen:
+            return dict(ref=self.seen[obj])
+        else:
+            ident = self.seen[obj]
+
+        ret = self._encode_complex(obj, context)
+        if ret is None:
+            raise TypeError("failed to encode %r (type: %s)" % (obj, type(obj)))
+
+        if "id" in ret:
+            if ret["id"] is False:
+                del self.seen[obj]
+            elif ret["id"] != self.seen[obj]:
+                raise RuntimeError("unexpected id change")
+        else:
+            ret["id"] = ident
+
+        return ret
+
+    def fill(self, obj, context, prefix, suffix, schemasuffix, storage, compression, **kwargs):
+        assert self.prefix == prefix
+        assert self.suffix == suffix
+        assert self.schemasuffix == schemasuffix
+        assert self.storage == storage
+        assert self.compression == compression
+        return self(obj, context=context)
+
+
+class BlobSerializer(Serializer):
+
+    class CompressPolicy(object):
+        enc2dec = {
+            zlib.compress: ("zlib", "decompress"),
+        }
+
+        @classmethod
+        def parse(cls, x):
+            if isinstance(x, cls):
+                return x
+            elif isinstance(x, dict):
+                return cls(**x)
+            elif callable(x):
+                return cls(enc=x)
+            elif len(x) == 2 and callable(x[0]):
+                return cls(enc=x[0], dec=x[1])
             else:
-                return {"id": ident, "json": obj}
+                raise TypeError("can't parse policy %r" % x)
 
-    schema = {"awkward": awkward.version.__version__,
-              "schema": fill(obj, "", prefix, suffix, schemasuffix, storage, compression, **kwargs)}
-    if prefix != "":
-        schema["prefix"] = prefix
+        def __init__(self, enc, dec=None, minsize=0, types=(object,), contexts=("*",)):
+            if dec is None:
+                dec = self.enc2dec[enc]
+            assert callable(enc)
+            assert isinstance(dec, tuple)
+            assert 0 <= minsize
+            assert isinstance(types, tuple)
+            assert isinstance(contexts, tuple)
+            self.enc = enc
+            self.dec = dec
+            self.minsize = 0
+            self.types = types
+            self.contexts = contexts
 
-    storage[name + schemasuffix] = json.dumps(schema).encode("ascii")
-    return schema
+        @property
+        def pair(self):
+            return (self.enc, self.dec)
 
-def deserialize(storage, name="", awkwardlib="awkward", whitelist=whitelist, cache=None):
+        def test(self, obj, context):
+            return (
+                obj.nbytes >= self.minsize and
+                issubclass(obj.dtype.type, tuple(self.types)) and
+                any(fnmatch.fnmatchcase(context, p) for p in self.contexts)
+            )
+
+    compression_default = [
+        CompressPolicy(
+            minsize=8192,
+            types=(numpy.bool_, numpy.bool, numpy.integer),
+            enc=zlib.compress
+        ),
+    ]
+
+    @classmethod
+    def _parse_compression(cls, compression):
+        if compression is True:
+            compression = cls.compression_default
+        if not compression:
+            compression = []
+        elif not isinstance(compression, (list, tuple)):
+            compression = [compression]
+
+        return list(map(cls.CompressPolicy.parse, compression))
+
+    def __init__(self, *args, **kwargs):
+        self.compression = kwargs.pop("compression", True)
+        self._parse_compression(self.compression)
+        super(BlobSerializer, self).__init__(*args, **kwargs)
+
+    def _put_raw(self, data, ref=None):
+        if ref is None:
+            ref = data
+        key = str(self.seen[ref]) + self.suffix
+        self.storage[self.prefix + key] = data
+        return dict(read=key)
+
+    def _encode_numpy(self, obj, context):
+        if obj.ndim > 1:
+            dtype = numpy.dtype((obj.dtype, obj.shape[1:]))
+        else:
+            dtype = obj.dtype
+
+        buf = None
+        for policy in self._parse_compression(self.compression):
+            if policy.test(obj, context):
+                buf = self.encode_call(
+                    policy.dec,
+                    self._put_raw(policy.enc(obj.ravel()), ref=obj),
+                )
+                break
+        else:
+            buf = self._put_raw(obj.ravel(), ref=obj)
+
+        return self.encode_call(
+            ["awkward", "numpy", "frombuffer"],
+            buf,
+            self(dtype),
+            self(obj.shape[0]),
+        )
+
+def serialize(obj, storage, name="", **kwargs):
+    if name:
+        kwargs.setdefault("prefix", name + kwargs.get("delimiter", ""))
+    return BlobSerializer(storage, **kwargs).store(name, obj)
+
+def deserialize(storage, name="", awkwardlib="awkward", whitelist=whitelist, cache=None, seen=None):
     import awkward.array.virtual
 
     schema = storage[name]
@@ -384,7 +534,8 @@ def deserialize(storage, name="", awkwardlib="awkward", whitelist=whitelist, cac
         raise ValueError("JSON object is not an awkward-array schema (missing 'awkward' field)")
 
     prefix = schema.get("prefix", "")
-    seen = {}
+    if seen is None:
+        seen = ObjRef()
 
     if isinstance(whitelist, str):
         whitelist = [whitelist]
@@ -438,16 +589,13 @@ def deserialize(storage, name="", awkwardlib="awkward", whitelist=whitelist, cac
                 out = topython(schema["python"])
 
             elif "ref" in schema:
-                if schema["ref"] in seen:
-                    out = seen[schema["ref"]]
-                else:
-                    out = awkward.array.virtual.VirtualArray(lambda: seen[schema["ref"]])
+                out = seen.obj(schema["ref"])
 
             else:
                 raise ValueError("unrecognized JSON object with fields {0}".format(", ".join(repr(x) for x in schema)))
 
             if "id" in schema:
-                seen[schema["id"]] = out
+                seen[out] = schema["id"]
             return out
 
         elif isinstance(schema, list):
@@ -556,7 +704,7 @@ def save(file, array, name=None, mode="a", **options):
     if isinstance(file, str) and not file.endswith(".awkd"):
         file = file + ".awkd"
 
-    alloptions = {"delimiter": "-", "suffix": ".raw", "schemasuffix": ".json", "compression": compression}
+    alloptions = {"delimiter": "-", "suffix": ".raw", "schemasuffix": ".json", "compression": True}
     alloptions.update(options)
     options = alloptions
 
@@ -632,7 +780,7 @@ class Load(Mapping):
 
 class hdf5(MutableMapping):
     def __init__(self, group, **options):
-        alloptions = {"compression": compression, "awkwardlib": "awkward", "whitelist": whitelist, "cache": None}
+        alloptions = {"compression": True, "awkwardlib": "awkward", "whitelist": whitelist, "cache": None}
         alloptions.update(options)
         self.options = alloptions
         self.options["delimiter"] = "/"

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -468,19 +468,9 @@ class BlobSerializer(Serializer):
                 any(fnmatch.fnmatchcase(context, p) for p in self.contexts)
             )
 
-    compression_default = [
-        CompressPolicy(
-            minsize=8192,
-            types=(numpy.bool_, numpy.bool, numpy.integer),
-            enc=zlib.compress
-        ),
-    ]
-
     @classmethod
     def _parse_compression(cls, comp):
-        if comp is True:
-            comp = compression
-        if not comp:
+        if comp is None:
             comp = []
         elif not isinstance(comp, (list, tuple)):
             comp = [comp]
@@ -488,7 +478,7 @@ class BlobSerializer(Serializer):
         return list(map(cls.CompressPolicy.parse, comp))
 
     def __init__(self, *args, **kwargs):
-        self.compression = kwargs.pop("compression", True)
+        self.compression = kwargs.pop("compression", compression)
         self._parse_compression(self.compression)
         super(BlobSerializer, self).__init__(*args, **kwargs)
 
@@ -714,7 +704,7 @@ def save(file, array, name=None, mode="a", **options):
     if isinstance(file, str) and not file.endswith(".awkd"):
         file = file + ".awkd"
 
-    alloptions = {"delimiter": "-", "suffix": ".raw", "schemasuffix": ".json", "compression": True}
+    alloptions = {"delimiter": "-", "suffix": ".raw", "schemasuffix": ".json", "compression": compression}
     alloptions.update(options)
     options = alloptions
 
@@ -790,7 +780,7 @@ class Load(Mapping):
 
 class hdf5(MutableMapping):
     def __init__(self, group, **options):
-        alloptions = {"compression": True, "awkwardlib": "awkward", "whitelist": whitelist, "cache": None}
+        alloptions = {"compression": compression, "awkwardlib": "awkward", "whitelist": whitelist, "cache": None}
         alloptions.update(options)
         self.options = alloptions
         self.options["delimiter"] = "/"

--- a/awkward/persist.py
+++ b/awkward/persist.py
@@ -515,9 +515,11 @@ class BlobSerializer(Serializer):
             self(obj.shape[0]),
         )
 
-def serialize(obj, storage, name="", **kwargs):
+def serialize(obj, storage, name="", delimiter="-", **kwargs):
+    if delimiter is None:
+        delimiter = ""
     if name:
-        kwargs.setdefault("prefix", name + kwargs.get("delimiter", ""))
+        kwargs.setdefault("prefix", name + delimiter)
     return BlobSerializer(storage, **kwargs).store(name, obj)
 
 def deserialize(storage, name="", awkwardlib="awkward", whitelist=whitelist, cache=None, seen=None):


### PR DESCRIPTION
This is a proposal to move the functionality of [`persist.serialize`](https://github.com/scikit-hep/awkward-array/blob/master/awkward/persist.py#L236) into a class.  
Following is a brief overview I'd be happy to elaborate on as questions arise.

# Why?
This change enables more customization of the internal behavior of `serialize`, in particular for the storing of NumPy arrays - which would require copying the entire function at the moment. Examples of such modifications are:
* storing NumPy arrays directly in an `h5py` storage as a `Dataset`
* chunking on save (injecting `ChunkedArray` of `VirutalArrays` around NumPy arrays)

### New Features
* Deduplication across multiple serializations to the same storage possible.
* Deduplication of deserialized objects possible (e.g. for adding *only new* stuff to a storage).
* Much less verbose parameter passing in `__awkward_serialize__` (compared to `__awkward_persist__`)

# Changes

## Externally visible
* `persist.deserialze` has a new keyword argument `seen` (generally not to be used)
* `persist.compress` and `persist.partner` moved (can be made backwards compatible)
* `__awkward_persist__` deprecated, replaced by `__awkward_serialize__` (different signature, see below)
* for instances of `numpy.ndarray`: serialization will first attempt using on-object methods (`__awkward_serialize__`, `__awkward_persist__`, `tojson`)

## Added
### `def __awkward_serialize__(self, serializer)`
Replaces `__awkward_persist__` with all its arguments effectively stored on the `Serializer` instance, which is now the only argument.

### `class Serializer(object)`

Stores serialization parameters: `storage`, `prefix`, `suffix`, `schemasuffix`.
Deduplication via `seen` is reused for multiple `store` calls.
Can also deduplicate deserialized objects when using `load`.

#### API of `Serializer` for usage in `__awkward_serialize__`
All following methods return deserialization expressions:
* `def __call__(self, obj, context)` to fully serialize (encode and store) any object (equivalent of `fill`).
* `def encode_call(self, func, *args, **kwargs)` to effectively encode `func(*args, **kwargs)`. `func` can be a callable or a function specification. `*args` and `**kwargs` need to be serialized already (e.g. via `__call__`)
* `def encode_json(self, obj)` encode `obj` using `jsonable`
* `def encode_python(self, obj)` encode `obj` using `frompython`

### `class BlobSerializer(Serializer)`

Stores NumPy arrays by compressing them first, according to `compression` which has the same signature as the original. `compression` is given during instantiation, but can also be modified on the instance itself.
Compression policies are implemented via a internal light-weight class `CompressPolicy`, which parses, type-checks, and test these policies.
The `persist.compress` `list` moved to `persist.BlobSerializer.compression_default`.
The `persist.partner` `dict` moved to `persist.BlobSerializer.CompressPolicy.enc2dec` (decode can also be directly passed to `CompressPolicy`).

### `class ObjRef(object)`

Internal helper for (non-hashable) object to reference ID lookups (via `id`). Also enables reference ID to object lookup, used by `deserialze`. Uses `self.idgen` iterable (e.g. a `itertools.counter`) to generate new reference IDs during `__getitem__` of unseen objects.