### PR TITLE
Don't let JaggedArray.fromoffsets construct from a view

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -134,6 +134,11 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
     @classmethod
     def fromoffsets(cls, offsets, content):
         offsets = cls._util_toarray(offsets, cls.INDEXTYPE, cls.numpy.ndarray)
+        if offsets.base is not None:
+            # We rely on the starts,stops slices to be views.
+            # If offsets is already a view, the base will not be offsets but its underlying base.
+            # Make a copy to prevent that
+            offsets = offsets.copy()
         return cls(offsets[:-1], offsets[1:], content)
 
     @classmethod


### PR DESCRIPTION
Prevents bugs such as:
```python
import awkward, numpy as np
offsets, = np.where([1, 0, 1, 0, 0, 1])
awkward.JaggedArray.fromoffsets(offsets, np.arange(5))
```