### PR TITLE
Adapt for Numpy 1.17.0

### DIFF
--- a/awkward/array/base.py
+++ b/awkward/array/base.py
@@ -378,7 +378,7 @@ class AwkwardArray(awkward.util.NDArrayOperatorsMixin):
         else:
             try:
                 return cls.numpy.frombuffer(value, dtype=getattr(value, "dtype", defaultdtype)).reshape(getattr(value, "shape", -1))
-            except AttributeError:
+            except (AttributeError, TypeError):
                 if len(value) == 0:
                     return cls.numpy.array(value, dtype=defaultdtype, copy=False)
                 else:

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Numpy changed its exception type for `numpy.fromiter(not-a-buffer)` from `AttributeError` (which didn't make much sense) to `TypeError` (which does). Now we check both in `AwkwardArray._util_toarray`. This should work for old and new Numpys and still distinguish between objects with a buffer protocol and sequence-like objects.