### PR TITLE
Fix issue #172

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -535,7 +535,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
 
                 counts = head.tojagged(self.counts)._content
 
-                indexes = self.numpy.array(head._content[:headoffsets[-1]], copy=True)
+                indexes = self.numpy.array(head._content[:headoffsets[-1]], dtype=self.INDEXTYPE, copy=True)
 
                 negatives = (indexes < 0)
                 indexes[negatives] += counts[negatives]

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Fixes JaggedArray.__getitem__ for integer indexes that have a too-small integer type; this MIGHT be the problem in #172.