### PR TITLE
Issue 176

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -1576,8 +1576,12 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         else:
             out = self.localindex[self.max() == self]
 
+        print("out", out.tolist())
+
         # workaround for lack of general out[...,:1] support
         nonempty = out.counts > 0
+        if self.offsetsaliased(out._starts, out._stops):
+            out.stops = out.stops.copy()
         out.stops[nonempty] = out.starts[nonempty] + 1
         return out
 

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -1576,8 +1576,6 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
         else:
             out = self.localindex[self.max() == self]
 
-        print("out", out.tolist())
-
         # workaround for lack of general out[...,:1] support
         nonempty = out.counts > 0
         if self.offsetsaliased(out._starts, out._stops):

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.12.5"
+__version__ = "0.12.6"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
The `starts` and `stops` of the output of `_argminmax` would ordinarily be aliased, so changing `stops` changes `starts`. That's undesirable if there are any subarrays with a repeated maximum (e.g. issue #176).

This is correcting a correction by @nsmith- in PR #160 (specifically, [these changes](https://github.com/scikit-hep/awkward-array/commit/128f70932eab9d2e8a2b526e6d5ca58a6e3b455e#diff-73e1845c17301820ef8803a3e92fa750R1533-R1535)). I don't know the original case that made a simple `[:, :1]` ineffective, but the correction should now be completely general.