### PR TITLE
Fix len of ChunkedArray after chunksizes changes

### DIFF
--- a/awkward/array/chunked.py
+++ b/awkward/array/chunked.py
@@ -117,7 +117,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
         until = min(until, len(self._chunks))
         for i in range(len(self._chunksizes), until):
             self._chunksizes.append(len(self._chunks[i]))
-        self._offsets = None
+            self._offsets = None
 
     def knowtype(self, at):
         if not 0 <= at < len(self._chunks):

--- a/awkward/array/chunked.py
+++ b/awkward/array/chunked.py
@@ -117,6 +117,7 @@ class ChunkedArray(awkward.array.base.AwkwardArray):
         until = min(until, len(self._chunks))
         for i in range(len(self._chunksizes), until):
             self._chunksizes.append(len(self._chunks[i]))
+        self._offsets = None
 
     def knowtype(self, at):
         if not 0 <= at < len(self._chunks):

--- a/tests/test_chunked.py
+++ b/tests/test_chunked.py
@@ -136,6 +136,11 @@ class Test(unittest.TestCase):
         assert a[[True, False, True, False, True, False, True, False, True, False], 0].tolist() == [0.0, 2.0, 4.0, 6.0, 8.0]
         assert a[[True, False, True, False, True, False, True, False, True, False], 1].tolist() == [0.0, 2.2, 4.4, 6.6, 8.8]
 
+    def test_chunked_flatten_len(self):
+        a = ChunkedArray([[[0, 1]], [[2, 3], [4, 5]], [[6, 7], [8, 9]]])
+        assert len(a) == 5
+        assert len(a.flatten()) == 10
+
     def test_appendable_append(self):
         a = AppendableArray(3, numpy.float64)
         assert a.tolist() == []


### PR DESCRIPTION
This addresses the following odd behavior:
```python
>>> import awkward
>>> a = awkward.ChunkedArray([[[0, 1]]])
>>> a
<ChunkedArray [[0 1]] at 0x7fb301038320>
>>> len(a)
1
>>> b = a.flatten()
>>> b
<ChunkedArray [0 1] at 0x7fb301038358>
>>> len(b)
1
```
`len` is determined from `offsets[-1]`, but `offsets` doesn't get updated after `flatten()`.