### PR TITLE
Make sure that classes generated on the fly are pickleable.

### DIFF
--- a/awkward/array/base.py
+++ b/awkward/array/base.py
@@ -78,6 +78,11 @@ class AwkwardArray(awkward.util.NDArrayOperatorsMixin):
         self.__dict__.update(out.__dict__)
         self.__class__ = out.__class__
 
+    def __reduce__(self):
+        state = {}
+        awkward.persist.serialize(self, state)
+        return (awkward.persist.deserialize, (state,))
+
     def _checkiter(self):
         if not self.allow_iter:
             raise RuntimeError("awkward.array.base.AwkwardArray.allow_iter is False; refusing to iterate")

--- a/awkward/version.py
+++ b/awkward/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
We had been using `__getstate__` and `__setstate__`, but these assume that a class can be referenced by a qualname for reconstruction (even though we never use it). The most complete (functional) way to pickle something is through `__reduce__`, which overcomes the problem of classes generated on the fly not having a qualname.