### PR TITLE
Fix iteration over Rows

### DIFF
--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -53,13 +53,25 @@ class Table(awkward.array.base.AwkwardArray):
                 return dict((n, self._table._try_tolist(x[self._index])) for n, x in self._table._contents.items())
 
         def __len__(self):
-            return len(self._table._contents)
+            if self._table.rowname == 'Row':
+                return len(self._table._contents)
+            else:
+                i = 0
+                while str(i) in self._table._contents:
+                    i += 1
+                return i
 
         def __iter__(self, checkiter=True):
             if checkiter:
                 self._table._checkiter()
-            for i in self._table._contents:
-                yield self._table._contents[i][self._index]
+            if self._table.rowname == 'Row':
+                for i in self._table._contents:
+                    yield i
+            else:
+                i = 0
+                while str(i) in self._table._contents:
+                    yield self._table._contents[str(i)][self._index]
+                    i += 1
 
         def __getitem__(self, where):
             if isinstance(where, awkward.util.string):

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -53,25 +53,25 @@ class Table(awkward.array.base.AwkwardArray):
                 return dict((n, self._table._try_tolist(x[self._index])) for n, x in self._table._contents.items())
 
         def __len__(self):
-            if self._table.rowname == 'Row':
-                return len(self._table._contents)
-            else:
+            if self._table.rowname == 'tuple':
                 i = 0
                 while str(i) in self._table._contents:
                     i += 1
                 return i
+            else:
+                return len(self._table._contents)
 
         def __iter__(self, checkiter=True):
             if checkiter:
                 self._table._checkiter()
-            if self._table.rowname == 'Row':
-                for i in self._table._contents:
-                    yield i
-            else:
+            if self._table.rowname == 'tuple':
                 i = 0
                 while str(i) in self._table._contents:
                     yield self._table._contents[str(i)][self._index]
                     i += 1
+            else:
+                for i in self._table._contents:
+                    yield i
 
         def __getitem__(self, where):
             if isinstance(where, awkward.util.string):

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -61,10 +61,8 @@ class Table(awkward.array.base.AwkwardArray):
         def __iter__(self, checkiter=True):
             if checkiter:
                 self._table._checkiter()
-            i = 0
-            while str(i) in self._table._contents:
-                yield self._table._contents[str(i)][self._index]
-                i += 1
+            for i in self._table._contents:
+                yield self._table._contents[i][self._index]
 
         def __getitem__(self, where):
             if isinstance(where, awkward.util.string):

--- a/awkward/array/table.py
+++ b/awkward/array/table.py
@@ -53,10 +53,7 @@ class Table(awkward.array.base.AwkwardArray):
                 return dict((n, self._table._try_tolist(x[self._index])) for n, x in self._table._contents.items())
 
         def __len__(self):
-            i = 0
-            while str(i) in self._table._contents:
-                i += 1
-            return i
+            return len(self._table._contents)
 
         def __iter__(self, checkiter=True):
             if checkiter:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -207,5 +207,5 @@ class Test(unittest.TestCase):
     def test_table_row_dict_iteration(self):
         column_dict = {'a': [1, 3], 'b': [2, 4]}
         a = Table(column_dict)
-        b = [set([row[key] for key in row]) for row in a]
-        assert b == [set([1, 2]), set([3, 4])]
+        b = [{key: row[key] for key in row} for row in a]
+        assert b == [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -195,7 +195,12 @@ class Test(unittest.TestCase):
                     iter(element)
         assert b == rows
 
-    def test_table_column_dict_iteration(self):
+    def test_table_column_dict_row_len(self):
+        column_dict = {'a': [1], 'b': [2]}
+        a = Table(column_dict)
+        assert len(a[0]) == 2
+
+    def test_table_column_dict_row_iteration(self):
         column_dict = {'a': [1, 3], 'b': [2, 4]}
         a = Table(column_dict)
         b = [set([element for element in row]) for row in a]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -182,7 +182,11 @@ class Test(unittest.TestCase):
         assert all(unzip[0] == left)
         assert all(unzip[1] == right)
 
-    def test_table_iteration(self):
+    def test_table_row_tuple_len(self):
+        a = Table([1], [2])
+        assert len(a[0]) == 2
+
+    def test_table_row_tuple_iteration(self):
         rows = [[1, 2], [3, 4]]
         columns = zip(*rows)
         a = Table(*columns)
@@ -195,13 +199,13 @@ class Test(unittest.TestCase):
                     iter(element)
         assert b == rows
 
-    def test_table_column_dict_row_len(self):
+    def test_table_row_dict_len(self):
         column_dict = {'a': [1], 'b': [2]}
         a = Table(column_dict)
         assert len(a[0]) == 2
 
-    def test_table_column_dict_row_iteration(self):
+    def test_table_row_dict_iteration(self):
         column_dict = {'a': [1, 3], 'b': [2, 4]}
         a = Table(column_dict)
-        b = [set([element for element in row]) for row in a]
+        b = [set([row[key] for key in row]) for row in a]
         assert b == [set([1, 2]), set([3, 4])]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -194,3 +194,9 @@ class Test(unittest.TestCase):
                 with self.assertRaises(TypeError, msg='Scalar row element should not be iterable'):
                     iter(element)
         assert b == rows
+
+    def test_table_column_dict_iteration(self):
+        column_dict = {'a': [1, 3], 'b': [2, 4]}
+        a = Table(column_dict)
+        b = [set([element for element in row]) for row in a]
+        assert b == [set([1, 2]), set([3, 4])]


### PR DESCRIPTION
Currently, iterating over a Row in a Table with columns that aren't labeled '0', '1', '2', etc., will fail, making it appear as if every Row is empty:
```python
>>> import awkward
>>> t = awkward.Table({'a': [1]})
<Table [<Row 0>] at 0x7fc15bf93090>
>>> t['a']
array([1])
>>> t[0]
<Row 0>
>>> len(t[0])     
0
```
This is fixed here, so that the actual OrderedDict of column names will be iterated over.