### PR TITLE
Add absolute_import needed for python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
 install:
   - pip install --upgrade setuptools_scm
   - pip install $NUMPY
-  - if [[ $TRAVIS_PYTHON_VERSION == *2.7* ]] ; then pip install "pandas==0.24.2"; else pip install "pandas==0.25.3" ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]] ; then pip install "pandas==0.24.2"; elif [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install "pandas==0.25.3" ; fi
   - if [[ $TRAVIS_PYTHON_VERSION = pypy* ]] ; then pip install "numpy<1.16.0" ; fi       # FIXME: pypy bug in numpy
   - python -c 'import numpy; print(numpy.__version__)'
   - pip install pytest pytest-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
 install:
   - pip install --upgrade setuptools_scm
   - pip install $NUMPY
+  - if [[ $TRAVIS_PYTHON_VERSION == *2.7* ]] ; then pip install "pandas==0.24.2"; else pip install "pandas==0.25.3" ; fi
   - if [[ $TRAVIS_PYTHON_VERSION = pypy* ]] ; then pip install "numpy<1.16.0" ; fi       # FIXME: pypy bug in numpy
   - python -c 'import numpy; print(numpy.__version__)'
   - pip install pytest pytest-runner

--- a/awkward/pandas.py
+++ b/awkward/pandas.py
@@ -2,6 +2,7 @@
 
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-array/blob/master/LICENSE
 
+from __future__ import absolute_import
 import pandas
 import pandas.api.extensions
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name = "awkward",
       test_suite = "tests",
       install_requires = ["numpy>=1.13.1"],
       setup_requires = ["pytest-runner"],
-      tests_require = ["pytest"],
+      tests_require = ["pytest", "pandas"],
       classifiers = [
           # "Development Status :: 1 - Planning",
           # "Development Status :: 2 - Pre-Alpha",

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,1 +1,5 @@
+import pytest
+pandas = pytest.importorskip("pandas")
+
+
 from awkward import pandas

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2,4 +2,11 @@ import pytest
 pandas = pytest.importorskip("pandas")
 
 
-from awkward import pandas
+@pytest.fixture
+def awkward_pandas():
+    from awkward import pandas
+    return pandas
+
+
+def test_import_pandas(awkward_pandas):
+    pass

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,1 @@
+from awkward import pandas


### PR DESCRIPTION
I'm not sure what the plan for python2 support is, but when using awkward array in python 2, the awkward.pandas module cannot be loaded, because there is a clash in the module name between pandas itself, and the awkward.pandas module.  The import that takes place internally for `pandas.api.extension` then fails:
```bash
$ python --version
Python 2.7.15

$ python -c "import awkward.pandas as mod;print(mod)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/ben/projects/awkward-array/awkward/pandas.py", line 6, in <module>
    import pandas.api.extensions
ImportError: No module named api.extensions
```

This is addressed by insisting on absollute_imports, which is default in python3 and needs importing from `__future__` in python2.