### PR TITLE
Added awkward.frompandas() for intuitive DataFrame -> Tables conversion

### DIFF
--- a/awkward/__init__.py
+++ b/awkward/__init__.py
@@ -26,11 +26,11 @@ from awkward.generate import fromiter
 from awkward.persist import serialize, deserialize, save, load, hdf5
 
 from awkward.arrow import toarrow, fromarrow, toparquet, fromparquet
-from awkward.util import topandas
+from awkward.util import frompandas, topandas
 
 # convenient access to the version number
 from awkward.version import __version__
 
-__all__ = ["numpy", "AwkwardArray", "ChunkedArray", "AppendableArray", "IndexedArray", "SparseArray", "JaggedArray", "MaskedArray", "BitMaskedArray", "IndexedMaskedArray", "Methods", "ObjectArray", "Table", "UnionArray", "VirtualArray", "StringArray", "fromiter", "serialize", "deserialize", "save", "load", "hdf5", "toarrow", "fromarrow", "toparquet", "fromparquet", "topandas", "__version__"]
+__all__ = ["numpy", "AwkwardArray", "ChunkedArray", "AppendableArray", "IndexedArray", "SparseArray", "JaggedArray", "MaskedArray", "BitMaskedArray", "IndexedMaskedArray", "Methods", "ObjectArray", "Table", "UnionArray", "VirtualArray", "StringArray", "fromiter", "serialize", "deserialize", "save", "load", "hdf5", "toarrow", "fromarrow", "toparquet", "fromparquet", "frompandas", "topandas", "__version__"]
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/awkward/util.py
+++ b/awkward/util.py
@@ -208,7 +208,20 @@ except AttributeError:
             __abs__ = _unary_method(um.absolute, 'abs')
             __invert__ = _unary_method(um.invert, 'invert')
 
-################################################################ conversion of arrays to Pandas
+################################################################ conversion of arrays from/to Pandas
+
+
+def frompandas(dataframe):
+    """Converts a Pandas DataFrame to an Awkward Table
+
+    :param dataframe: Pandas DataFrame
+    :return: awkward.Table
+    """
+
+    import awkward.array.table
+
+    return awkward.Table({name: dataframe[name].values for name in dataframe.columns})
+
 
 def topandas(array, flatten=False):
     import pandas


### PR DESCRIPTION
Initial support for a simple function that converts a Pandas DataFrame to an Awkward Tables. The new `awkward.frompandas(dataframe)` does:
`return awkward.Table({name: dataframe[name].values for name in dataframe.columns})`

Closes #215