### PR TITLE
Create special exception in jagged fromoffsets for zero-copy arrow conversion

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -12,7 +12,6 @@ try:
 except ImportError:
     from collections import Iterable
 
-import pyarrow
 import awkward.array.base
 import awkward.persist
 import awkward.type
@@ -135,10 +134,10 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
     @classmethod
     def fromoffsets(cls, offsets, content):
         offsets = cls._util_toarray(offsets, cls.INDEXTYPE, cls.numpy.ndarray)
-        if hasattr(offsets.base, 'base') and isinstance(offsets.base.base, pyarrow.lib.Buffer):
+        if hasattr(offsets.base, 'base') and str(type(offsets.base.base)) == "<class 'pyarrow.lib.Buffer'>":
             # special exception to prevent copy in awkward.fromarrow
             pass
-        if offsets.base is not None:
+        elif offsets.base is not None:
             # We rely on the starts,stops slices to be views.
             # If offsets is already a view, the base will not be offsets but its underlying base.
             # Make a copy to prevent that

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -134,7 +134,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
     @classmethod
     def fromoffsets(cls, offsets, content):
         offsets = cls._util_toarray(offsets, cls.INDEXTYPE, cls.numpy.ndarray)
-        if hasattr(offsets.base, 'base') and str(type(offsets.base.base)) == "<class 'pyarrow.lib.Buffer'>":
+        if hasattr(offsets.base, 'base') and type(offsets.base.base).__module__ == "pyarrow.lib" and type(offsets.base.base).__name__ == "Buffer":
             # special exception to prevent copy in awkward.fromarrow
             pass
         elif offsets.base is not None:

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     from collections import Iterable
 
+import pyarrow
 import awkward.array.base
 import awkward.persist
 import awkward.type
@@ -134,6 +135,9 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
     @classmethod
     def fromoffsets(cls, offsets, content):
         offsets = cls._util_toarray(offsets, cls.INDEXTYPE, cls.numpy.ndarray)
+        if hasattr(offsets.base, 'base') and isinstance(offsets.base.base, pyarrow.lib.Buffer):
+            # special exception to prevent copy in awkward.fromarrow
+            pass
         if offsets.base is not None:
             # We rely on the starts,stops slices to be views.
             # If offsets is already a view, the base will not be offsets but its underlying base.

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -389,6 +389,17 @@ class Test(unittest.TestCase):
             b = awkward.fromarrow(batch)
             assert a.tolist() == b["a"].tolist()
 
+    def test_arrow_fromarrow_zerocopy(self):
+        if pyarrow is None:
+            pytest.skip("unable to import pyarrow")
+        else:
+            a = awkward.fromiter([[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6, 7.7, 8.8], [], [9.9]])
+            b = awkward.toarrow(a)
+            c = awkward.fromarrow(b)
+            assert c.offsets.ctypes.data == b.buffers()[1].address
+            assert c.content.ctypes.data == b.buffers()[3].address
+            assert c.offsetsaliased(c.starts, c.stops)
+
     # def test_arrow_writeparquet(self):
     #     if pyarrow is None:
     #         pytest.skip("unable to import pyarrow")


### PR DESCRIPTION
I'm still not sure this is the best idea.