### PR TITLE
Add LargeListArray, LargeBinaryArray, LargeStringArray to pyarrow serialization options.

### DIFF
--- a/awkward/arrow.py
+++ b/awkward/arrow.py
@@ -152,9 +152,11 @@ def toarrow(obj, use_large_index=False):
         elif isinstance(obj, awkward.array.objects.StringArray):
             if obj.encoding is None and hasattr(pyarrow.BinaryArray, 'from_buffers'):
                 arrow_type = pyarrow.BinaryArray
+                arrow_offset_type = pyarrow.binary()
                 if hasattr(pyarrow, 'LargeBinaryArray') and use_large_index:
                     arrow_type = pyarrow.LargeBinaryArray
-                convert = lambda length, offsets, content: arrow_type.from_buffers(pyarrow.binary(), length, [None, offsets, content])
+                    arrow_offset_type = pyarrow.large_binary()
+                convert = lambda length, offsets, content: arrow_type.from_buffers(arrow_offset_type, length, [None, offsets, content])
             elif codecs.lookup(obj.encoding) is codecs.lookup("utf-8") or obj.encoding is None:
                 arrow_type = pyarrow.StringArray
                 if hasattr(pyarrow, 'LargeStringArray') and use_large_index:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -50,10 +50,16 @@ class Test(unittest.TestCase):
             assert awkward.fromarrow(awkward.toarrow(a)).tolist() == a.tolist()
             a = awkward.fromiter([["one", "two", "three"], [], ["four", "five"]])
             assert awkward.fromarrow(awkward.toarrow(a)).tolist() == a.tolist()
-            a = awkward.fromiter([b"one", b"two", b"three"])
-            assert awkward.fromarrow(awkward.toarrow(a)).tolist() == ["one", "two", "three"]
-            a = awkward.fromiter([[b"one", b"two", b"three"], [], [b"four", b"five"]])
-            assert awkward.fromarrow(awkward.toarrow(a)).tolist() == [["one", "two", "three"], [], ["four", "five"]]
+            if hasattr(pyarrow.BinaryArray, 'from_buffers'):
+                a = awkward.fromiter([b"one", b"two", b"three"])
+                assert awkward.fromarrow(awkward.toarrow(a)).tolist() == [b"one", b"two", b"three"]
+                a = awkward.fromiter([[b"one", b"two", b"three"], [], [b"four", b"five"]])
+                assert awkward.fromarrow(awkward.toarrow(a)).tolist() == [[b"one", b"two", b"three"], [], [b"four", b"five"]]
+            else:
+                a = awkward.fromiter([b"one", b"two", b"three"])
+                assert awkward.fromarrow(awkward.toarrow(a)).tolist() == ["one", "two", "three"]
+                a = awkward.fromiter([[b"one", b"two", b"three"], [], [b"four", b"five"]])
+                assert awkward.fromarrow(awkward.toarrow(a)).tolist() == [["one", "two", "three"], [], ["four", "five"]]
 
     def test_arrow_array(self):
         if pyarrow is None:


### PR DESCRIPTION
There's now a 64-bit indexed ListArray, StringArray, and BinaryArray types in pyarrow.

I've put in a defaulted-false argument in `toarrow()` where the user can drive the index type used when serializing jagged arrays.