### PR TITLE
Allow ufunc on VirtualArray to use numpy 'out'

### DIFF
--- a/awkward/array/virtual.py
+++ b/awkward/array/virtual.py
@@ -388,7 +388,7 @@ class VirtualArray(awkward.array.base.AwkwardArray):
             self._delitem.append(where)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        if "out" in kwargs:
+        if "out" in kwargs and isinstance(kwargs["out"], self.awkward.AwkwardArray):
             raise NotImplementedError("in-place operations not supported")
 
         if method != "__call__":


### PR DESCRIPTION
If all inputs are plain numpy or only wrapped by VirtualArray, then
numpy should not have any trouble doing in-place ops.  If any other
awkward types are passed in, they will fail in their respective ufunc
callbacks.  So we are really only losing the ability to throw early before
materializing in all cases.