### PR TITLE
Fix unexpected dtype change in JaggedArray._concatenate_axis1

### DIFF
--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -1689,7 +1689,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             if len(ick) == 0:
                 dtype = np.dtype(arrays[0].dtype)
             else:
-                dtype = np.dtype(sum(ick), False)
+                dtype = np.dtype(np.sum(ick), False)
             allbools = not np.any([a.dtype != np.dtype(bool) for a in arrays])
             dtype = np.dtype(bool) if allbools else dtype
             return dtype

--- a/awkward/array/jagged.py
+++ b/awkward/array/jagged.py
@@ -1689,7 +1689,7 @@ class JaggedArray(awkward.array.base.AwkwardArrayWithContent):
             if len(ick) == 0:
                 dtype = np.dtype(arrays[0].dtype)
             else:
-                dtype = np.dtype(np.sum(ick), False)
+                dtype = np.dtype(np.array(ick).dtype, False)
             allbools = not np.any([a.dtype != np.dtype(bool) for a in arrays])
             dtype = np.dtype(bool) if allbools else dtype
             return dtype

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -479,6 +479,12 @@ class Test(unittest.TestCase):
         c3 = a3.concatenate([b3], axis=1)
         assert c3.tolist() == [[],[0.,1.1,2.2,6.5,7.6,8.7,9.8,10.9],[4.3,5.4],[5.5,6.6,7.7,8.8,9.9]]
 
+        # Test type consistency
+        for dt in numpy.int32, numpy.int64, numpy.float32, numpy.float64:
+            a = JaggedArray([0], [1], numpy.ones(1, dtype=dt))
+            b = a.concatenate([a], axis=1)
+            self.assertEqual(dt, b.type.to.to)
+
 
     def test_jagged_get(self):
         a = JaggedArray.fromoffsets([0, 3, 3, 8, 10, 10], [0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])


### PR DESCRIPTION
`JaggedArray._concatenate_axis1` performs an unexpected dtype change, e.g. two `JaggedArray`s with `np.float32` dtype will result in one `JaggedArray` with dtype `np.float64`.

This is caused by the [built-in `sum(x)` function](https://docs.python.org/3/library/functions.html#sum) which does behave like `reduce(lambda a, b: a + b, x, int(0))` i.e. with an explicit `initializer=0` for [`reduce`](https://docs.python.org/3/library/functools.html#functools.reduce).

Using [`numpy.sum`](https://numpy.org/doc/1.18/reference/generated/numpy.sum.html) is not an option either since it has special dtype determination rules regarding integers.

I've also added a corresponding test.

