### PR TITLE
make sure deserialize function recongnises awkward0 name as well

### DIFF
--- a/awkward0/persist.py
+++ b/awkward0/persist.py
@@ -511,8 +511,8 @@ def deserialize(storage, name="", whitelist=whitelist, cache=None, seen=None):
         schema = schema.decode("ascii")
     schema = json.loads(schema)
 
-    if "awkward" not in schema:
-        raise ValueError("JSON object is not an Awkward Array schema (missing 'awkward' field)")
+    if "awkward" not in schema and "awkward0" not in schema:
+        raise ValueError("JSON object is not an Awkward Array schema (missing 'awkward' or 'awkward0' field). schema is: {}".format(schema))
 
     prefix = schema.get("prefix", "")
     if seen is None:

--- a/awkward0/version.py
+++ b/awkward0/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
as the title says. Test before were failing with:
```python
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

storage = {'': b'{"awkward0": "0.15.2", "schema": {"call": ["awkward0", "numpy", "frombuffer"], "args": [{"read": "0"}, {"dtype"...7, 78, 79, 80, 81, 82, 83, 84,
       85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99],
      dtype=uint16)}
name = ''
whitelist = [['numpy', 'frombuffer'], ['zlib', 'decompress'], ['lzma', 'decompress'], ['backports.lzma', 'decompress'], ['lz4.block', 'decompress'], ['awkward0', '*Array'], ...]
cache = None, seen = None

    def deserialize(storage, name="", whitelist=whitelist, cache=None, seen=None):
        import awkward0.array.virtual

        schema = storage[name]
        if isinstance(schema, numpy.ndarray):
            schema = schema.tostring()
        if isinstance(schema, bytes):
            schema = schema.decode("ascii")
        schema = json.loads(schema)

        if "awkward" not in schema:
>           raise ValueError("JSON object is not an Awkward Array schema (missing 'awkward' field)")
E           ValueError: JSON object is not an Awkward Array schema (missing 'awkward' field)

awkward0/persist.py:515: ValueError
```